### PR TITLE
31 Extend transformer public API to expose the change information

### DIFF
--- a/transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -61,6 +61,7 @@ import org.eclipse.transformer.util.FileUtils;
 import aQute.lib.io.IO;
 import aQute.lib.utf8properties.UTF8Properties;
 import aQute.libg.uri.URIUtil;
+import org.eclipse.transformer.action.Changes;
 
 public class Transformer {
     // TODO: Make this an enum?
@@ -486,6 +487,12 @@ public class Transformer {
 
     private String[] args;
     private CommandLine parsedArgs;
+
+    private Changes lastActiveChanges;
+
+    public Changes getLastActiveChanges() {
+        return lastActiveChanges;
+    }
 
     /**
      * Set default resource references for the several 'RULE" options.
@@ -1389,6 +1396,13 @@ public class Transformer {
                 acceptedAction.getLastActiveChanges().display( getLogger(), inputPath, outputPath );
             }
         }
+        
+        public Changes getLastActiveChanges() {
+            if (acceptedAction != null) {
+                return acceptedAction.getLastActiveChanges();
+            }
+            return null;
+        }
     }
 
     public int run() {
@@ -1451,6 +1465,7 @@ public class Transformer {
 
         try {
             options.transform(); // throws JakartaTransformException
+            lastActiveChanges = options.getLastActiveChanges();
         } catch ( TransformException e ) {
             dual_error("Transform failure:", e);
             return TRANSFORM_ERROR_RC;


### PR DESCRIPTION
Fixes https://github.com/eclipse/transformer/issues/31

Signed-off-by: JF Denise <jdenise@redhat.com>

Expose changes that could have occurred. We have an immediat use-case for it. If the transformed jar is signed, action must be taken.
