### PR TITLE
Add simple Maven Plugin

### DIFF
--- a/org.eclipse.transformer.maven/pom.xml
+++ b/org.eclipse.transformer.maven/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	* Copyright (c) 2020 Contributors to the Eclipse Foundation
+	*
+	* This program and the accompanying materials are made available under the
+	* terms of the Eclipse Public License 2.0 which is available at
+	* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+	* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+	*
+	* SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+		<groupId>org.eclipse.transformer</groupId>
+		<artifactId>org.eclipse.transformer.parent</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.transformer.maven</artifactId>
+	<description>Eclipse Transformer :: Maven Plugin</description>
+	<packaging>maven-plugin</packaging>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<url>https://projects.eclipse.org/projects/technology.transformer</url>
+
+
+    <properties>
+        <maven-plugin.prefix>transform</maven-plugin.prefix>
+    </properties>
+
+    <dependencies>
+        <dependency>
+			<groupId>org.eclipse.transformer</groupId>
+			<artifactId>org.eclipse.transformer.cli</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+        <dependency>
+			<groupId>javax.inject</groupId>
+			<artifactId>javax.inject</artifactId>
+			<!-- needed in compile scope to instantiate Provider org.eclipse.sisu.space.SisuIndexAPT6 -->
+			<scope>compile</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+		</dependency>
+
+        <!-- TESTS -->
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-aether-provider</artifactId>
+        </dependency>
+        <dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+        <dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-migrationsupport</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+        </dependency>
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-api</artifactId>
+		</dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive  combine.self="override"/>
+				</configuration>
+			</plugin>
+        </plugins>
+    </build>
+</project>

--- a/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
+++ b/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
@@ -1,0 +1,194 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package org.eclipse.transformer.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.eclipse.transformer.Transformer;
+import org.eclipse.transformer.jakarta.JakartaTransformer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is a Maven plugin which runs the Eclipse Transformer on build artifacts as part of the build.
+ */
+@Mojo(name = "run", requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM, defaultPhase = LifecyclePhase.PACKAGE, requiresProject = true, threadSafe = true)
+public class TransformMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(defaultValue = "false", property = "transformer-plugin.invert", required = true)
+    private Boolean invert;
+
+    @Parameter(defaultValue = "true", property = "transformer-plugin.overwrite", required = true)
+    private Boolean overwrite;
+
+    @Parameter(property = "transformer-plugin.renames", defaultValue = "")
+    private String rulesRenamesUri;
+
+    @Parameter(property = "transformer-plugin.versions", defaultValue = "")
+    private String rulesVersionUri;
+
+    @Parameter(property = "transformer-plugin.bundles", defaultValue = "")
+    private String rulesBundlesUri;
+
+    @Parameter(property = "transformer-plugin.direct", defaultValue = "")
+    private String rulesDirectUri;
+
+    @Parameter(property = "transformer-plugin.xml", defaultValue = "")
+    private String rulesXmlsUri;
+
+    @Parameter(defaultValue = "transformed")
+    private String classifier;
+
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
+    private File outputDirectory;
+
+    @Component
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * Main execution point of the plugin. This looks at the attached artifacts, and runs the transformer on them.
+     * @throws MojoFailureException Thrown if there is an error during plugin execution
+     */
+    public void execute() throws MojoFailureException {
+        final Transformer transformer = getTransformer();
+
+        final Artifact[] sourceArtifacts = getSourceArtifacts();
+        for (final Artifact sourceArtifact : sourceArtifacts) {
+            transform(transformer, sourceArtifact);
+        }
+    }
+
+    /**
+     * This runs the transformation process on the source artifact with the transformer provided.
+     * The transformed artifact is attached to the project.
+     * @param transformer The Transformer to use for the transformation
+     * @param sourceArtifact The Artifact to transform
+     * @throws MojoFailureException if plugin execution fails
+     */
+    public void transform(final Transformer transformer, final Artifact sourceArtifact) throws MojoFailureException {
+
+        final String sourceClassifier = sourceArtifact.getClassifier();
+        final String targetClassifier = (sourceClassifier == null || sourceClassifier.length() == 0) ?
+            this.classifier : sourceClassifier + "-" + this.classifier;
+
+        final File targetFile = new File(outputDirectory,
+            sourceArtifact.getArtifactId() + "-" +
+                targetClassifier + "-" + sourceArtifact.getVersion() + "."
+                + sourceArtifact.getType());
+
+        final List<String> args = new ArrayList<>();
+        args.add(sourceArtifact.getFile().getAbsolutePath());
+        args.add(targetFile.getAbsolutePath());
+
+        if (this.overwrite) {
+            args.add("-o");
+        }
+
+        transformer.setArgs(args.toArray(new String[0]));
+        int rc = transformer.run();
+
+        if (rc != 0) {
+            throw new MojoFailureException("Transformer failed with an error: " + Transformer.RC_DESCRIPTIONS[rc]);
+        }
+
+        projectHelper.attachArtifact(
+            project,
+            sourceArtifact.getType(),
+            targetClassifier,
+            targetFile
+        );
+    }
+
+    /**
+     * Builds a configured transformer for the specified source and target artifacts
+     * @return A configured transformer
+     */
+    public Transformer getTransformer() {
+        final Transformer transformer = new Transformer(System.out, System.err);
+        transformer.setOptionDefaults(JakartaTransformer.class, getOptionDefaults());
+        return transformer;
+    }
+
+    /**
+     * Gets the source artifacts that should be transformed
+     * @return an array to artifacts to be transformed
+     */
+    public Artifact[] getSourceArtifacts() {
+        List<Artifact> artifactList = new ArrayList<Artifact>();
+        if (project.getArtifact() != null && project.getArtifact().getFile() != null) {
+            artifactList.add(project.getArtifact());
+        }
+
+        for (final Artifact attachedArtifact : project.getAttachedArtifacts()) {
+            if (attachedArtifact.getFile() != null) {
+                artifactList.add(attachedArtifact);
+            }
+        }
+
+        return artifactList.toArray(new Artifact[0]);
+    }
+
+    private Map<Transformer.AppOption, String> getOptionDefaults() {
+        HashMap<Transformer.AppOption, String> optionDefaults = new HashMap();
+        optionDefaults.put(Transformer.AppOption.RULES_RENAMES, isEmpty(rulesRenamesUri) ? "jakarta-renames.properties" : rulesRenamesUri);
+        optionDefaults.put(Transformer.AppOption.RULES_VERSIONS, isEmpty(rulesVersionUri) ? "jakarta-versions.properties" : rulesVersionUri);
+        optionDefaults.put(Transformer.AppOption.RULES_BUNDLES, isEmpty(rulesBundlesUri) ? "jakarta-bundles.properties" : rulesBundlesUri);
+        optionDefaults.put(Transformer.AppOption.RULES_DIRECT, isEmpty(rulesDirectUri) ? "jakarta-direct.properties" : rulesDirectUri);
+        optionDefaults.put(Transformer.AppOption.RULES_MASTER_TEXT, isEmpty(rulesXmlsUri) ? "jakarta-text-master.properties" : rulesXmlsUri);
+        return optionDefaults;
+    }
+
+    private boolean isEmpty(final String input) {
+        return input == null || input.trim().length() == 0;
+    }
+
+    void setProject(MavenProject project) {
+        this.project = project;
+    }
+
+    void setClassifier(String classifier) {
+        this.classifier = classifier;
+    }
+
+    MavenProjectHelper getProjectHelper() {
+        return projectHelper;
+    }
+
+    void setProjectHelper(MavenProjectHelper projectHelper) {
+        this.projectHelper = projectHelper;
+    }
+
+    void setOverwrite(Boolean overwrite) {
+        this.overwrite = overwrite;
+    }
+
+    void setOutputDirectory(File outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+}

--- a/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/EchoService.java
+++ b/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/EchoService.java
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package org.eclipse.transformer.maven;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("echo")
+public class EchoService {
+
+    @POST
+    @Produces("text/plain")
+    @Consumes("text/plain")
+    public String echo(final String input) {
+        return input;
+    }
+
+
+}

--- a/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
+++ b/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
@@ -1,0 +1,165 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package org.eclipse.transformer.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.plugin.testing.resources.TestResources;
+import org.apache.maven.plugin.testing.stubs.DefaultArtifactHandlerStub;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.eclipse.transformer.Transformer;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TransformMojoTest {
+
+    @Rule
+    public MojoRule rule = new MojoRule();
+
+    @Rule
+    public TestResources resources = new TestResources();
+
+    @Test
+    public void testProjectArtifactTransformerPlugin() throws Exception {
+        final TransformMojo mojo = new TransformMojo();
+        mojo.setProjectHelper(this.rule.lookup(MavenProjectHelper.class));
+        mojo.setOverwrite(true);
+        mojo.setOutputDirectory(new File("target"));
+
+        Assertions.assertNotNull(mojo);
+
+        final File targetDirectory = this.resources.getBasedir("transform-build-artifact");
+        final File modelDirectory = new File(targetDirectory,"target/model" );
+        final File pom = new File(targetDirectory, "pom.xml");
+
+        final MavenProject mavenProject = createMavenProject(modelDirectory, pom, "war", "rest-sample");
+        mavenProject.getArtifact().setFile(createService());
+
+        mojo.setProject(mavenProject);
+        mojo.setClassifier("transformed");
+
+        final Artifact[] sourceArtifacts = mojo.getSourceArtifacts();
+        Assertions.assertEquals(1, sourceArtifacts.length);
+        Assertions.assertEquals("org.superbiz.rest", sourceArtifacts[0].getGroupId());
+        Assertions.assertEquals("rest-sample", sourceArtifacts[0].getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", sourceArtifacts[0].getVersion());
+        Assertions.assertEquals("war", sourceArtifacts[0].getType());
+        Assertions.assertNull(sourceArtifacts[0].getClassifier());
+
+        final Transformer transformer = mojo.getTransformer();
+        Assertions.assertNotNull(transformer);
+
+        mojo.transform(transformer, sourceArtifacts[0]);
+
+        Assertions.assertEquals(1, mavenProject.getAttachedArtifacts().size());
+        final Artifact transformedArtifact = mavenProject.getAttachedArtifacts().get(0);
+
+        Assertions.assertEquals("org.superbiz.rest", transformedArtifact.getGroupId());
+        Assertions.assertEquals("rest-sample", transformedArtifact.getArtifactId());
+        Assertions.assertEquals("1.0-SNAPSHOT", transformedArtifact.getVersion());
+        Assertions.assertEquals("war", transformedArtifact.getType());
+        Assertions.assertEquals("transformed", transformedArtifact.getClassifier());
+    }
+
+    @Test
+    public void testMultipleArtifactTransformerPlugin() throws Exception {
+        final TransformMojo mojo = new TransformMojo();
+        mojo.setOverwrite(true);
+        mojo.setProjectHelper(this.rule.lookup(MavenProjectHelper.class));
+
+        Assertions.assertNotNull(mojo);
+
+        final File targetDirectory = this.resources.getBasedir("transform-build-artifact");
+        final File modelDirectory = new File(targetDirectory,"target/model" );
+        final File pom = new File(targetDirectory, "pom.xml");
+
+        final MavenProject mavenProject = createMavenProject(modelDirectory, pom, "pom", "simple-service");
+
+        mojo.setProject(mavenProject);
+        mojo.setClassifier("transformed");
+        mojo.setOutputDirectory(new File("target"));
+
+        mojo.getProjectHelper().attachArtifact(mavenProject, "zip", "test1", createService());
+        mojo.getProjectHelper().attachArtifact(mavenProject, "zip", "test2", createService());
+        mojo.getProjectHelper().attachArtifact(mavenProject, "zip", "test3", createService());
+
+        final Artifact[] sourceArtifacts = mojo.getSourceArtifacts();
+        Assertions.assertEquals(3, sourceArtifacts.length);
+
+        for (int i = 0; i < 3; i++) {
+            Assertions.assertEquals("org.superbiz.rest", sourceArtifacts[i].getGroupId());
+            Assertions.assertEquals("simple-service", sourceArtifacts[i].getArtifactId());
+            Assertions.assertEquals("1.0-SNAPSHOT", sourceArtifacts[i].getVersion());
+            Assertions.assertEquals("zip", sourceArtifacts[i].getType());
+            Assertions.assertEquals("test" + (i + 1), sourceArtifacts[i].getClassifier());
+        }
+
+        final Transformer transformer = mojo.getTransformer();
+        Assertions.assertNotNull(transformer);
+
+        for (int i = 0; i < 3; i++) {
+            mojo.transform(transformer, sourceArtifacts[i]);
+        }
+
+        Assertions.assertEquals(6, mavenProject.getAttachedArtifacts().size());
+        Set<String> classifiers = mavenProject.getAttachedArtifacts().stream()
+            .filter(a -> (a.getType().equals("zip") && a.getArtifactId().equals("simple-service")))
+            .map(a -> a.getClassifier())
+            .collect(Collectors.toSet());
+
+        Assertions.assertEquals(6, mavenProject.getAttachedArtifacts().size());
+        Assertions.assertTrue(classifiers.contains("test1"));
+        Assertions.assertTrue(classifiers.contains("test2"));
+        Assertions.assertTrue(classifiers.contains("test3"));
+        Assertions.assertTrue(classifiers.contains("test1-transformed"));
+        Assertions.assertTrue(classifiers.contains("test2-transformed"));
+        Assertions.assertTrue(classifiers.contains("test3-transformed"));
+    }
+
+    public MavenProject createMavenProject(final File modelDirectory, final File pom, final String packaging, final String artfifactId) {
+        final MavenProject mavenProject = new MavenProject();
+        mavenProject.setFile(pom);
+        mavenProject.setGroupId("org.superbiz.rest");
+        mavenProject.setArtifactId(artfifactId);
+        mavenProject.setVersion("1.0-SNAPSHOT");
+        mavenProject.setPackaging(packaging);
+        mavenProject.getBuild().setDirectory( modelDirectory.getParentFile().getAbsolutePath());
+        mavenProject.getBuild().setOutputDirectory( modelDirectory.getAbsolutePath());
+        mavenProject.setArtifact(new DefaultArtifact(
+            mavenProject.getGroupId(), mavenProject.getArtifactId(), mavenProject.getVersion(), (String)null, "war", (String)null,
+            new DefaultArtifactHandlerStub(packaging, null)
+        ));
+        return mavenProject;
+    }
+
+    public File createService() throws IOException {
+        final File tempFile = File.createTempFile("service", ".war");
+        tempFile.delete();
+
+        final WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "service.war")
+            .addClass(EchoService.class);
+
+        webArchive.as(ZipExporter.class).exportTo(tempFile, true);
+        return tempFile;
+    }
+}

--- a/org.eclipse.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
+++ b/org.eclipse.transformer.maven/src/test/projects/transform-build-artifact/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	* Copyright (c) 2020 Contributors to the Eclipse Foundation
+	*
+	* This program and the accompanying materials are made available under the
+	* terms of the Eclipse Public License 2.0 which is available at
+	* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+	* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+	*
+	* SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.superbiz.rest</groupId>
+    <artifactId>rest-sample</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <name>rest-sample Maven Webapp</name>
+    <url>http://www.example.com</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>rest-sample</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>org.eclipse.transformer.maven</artifactId>
+                <version>${revision}</version>
+                <configuration>
+
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,15 @@
 		<assertj.version>3.16.1</assertj.version>
 		<!-- Reproducible build -->
 		<project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
+		<maven.version>3.2.2</maven.version>
+		<maven-test-harness.version>3.2.0</maven-test-harness.version>
 		<shrinkwrap.version>1.2.6</shrinkwrap.version>
 	</properties>
 
 	<modules>
 		<module>org.eclipse.transformer</module>
 		<module>org.eclipse.transformer.cli</module>
+		<module>org.eclipse.transformer.maven</module>
 	</modules>
 
 	<url>https://projects.eclipse.org/projects/technology.transformer</url>
@@ -258,6 +261,10 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+				<plugin>
+					<artifactId>maven-plugin-plugin</artifactId>
+					<version>3.6.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -334,6 +341,12 @@
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-api</artifactId>
+				<version>${junit-jupiter.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-migrationsupport</artifactId>
 				<version>${junit-jupiter.version}</version>
 				<scope>test</scope>
 			</dependency>
@@ -428,6 +441,53 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-plugin-api</artifactId>
+				<version>2.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.plugin-tools</groupId>
+				<artifactId>maven-plugin-annotations</artifactId>
+				<version>3.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-utils</artifactId>
+				<version>3.0.17</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-model</artifactId>
+				<version>${maven.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-core</artifactId>
+				<version>${maven.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-artifact</artifactId>
+				<version>${maven.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-compat</artifactId>
+				<version>${maven.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.plugin-testing</groupId>
+				<artifactId>maven-plugin-testing-harness</artifactId>
+				<version>${maven-test-harness.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-aether-provider</artifactId>
+				<version>${maven.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.jboss.shrinkwrap</groupId>
 				<artifactId>shrinkwrap-api</artifactId>
 				<version>${shrinkwrap.version}</version>
@@ -437,6 +497,12 @@
 				<groupId>org.jboss.shrinkwrap</groupId>
 				<artifactId>shrinkwrap-impl-base</artifactId>
 				<version>${shrinkwrap.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>javax</groupId>
+				<artifactId>javaee-api</artifactId>
+				<version>8.0.1</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
We discussed this a bit on the old repository, so here it is, rebased against the new Maven build. See https://github.com/tbitonti/jakartaee-prototype/pull/102.

The Mojo provides a classifier parameter, and any attached artifacts get transformed, and the transformed artifacts are attached with whatever value is specified appended to the artifacts classifier.

For example, in the TomEE build we have the following plugin config:
```
      <plugin>
        <groupId>org.eclipse.transformer</groupId>
        <artifactId>org.eclipse.transformer.mave
        <version>0.1.1-SNAPSHOT</version>
        <configuration>
          <classifier>jakartaee9</classifier>
        </configuration>
        <executions>
          <execution>
            <goals>
              <goal>run</goal>
            </goals>
            <phase>package</phase>
          </execution>
        </executions>
      </plugin>
```

And the module has the following attached artifacts:

org.apache.tomee:apache-tomee:webprofile:8.0.3-SNAPSHOT:zip
org.apache.tomee:apache-tomee:microprofile:8.0.3-SNAPSHOT:zip
org.apache.tomee:apache-tomee:plume:8.0.3-SNAPSHOT:zip
org.apache.tomee:apache-tomee:plus:8.0.3-SNAPSHOT:zip

Once the plugin is run, the following additional artifacts are attached:

org.apache.tomee:apache-tomee:webprofile-jakartaee9:8.0.3-SNAPSHOT:zip
org.apache.tomee:apache-tomee:microprofile-jakartaee9:8.0.3-SNAPSHOT:zip
org.apache.tomee:apache-tomee:plume-jakartaee9:8.0.3-SNAPSHOT:zip
org.apache.tomee:apache-tomee:plus-jakartaee9:8.0.3-SNAPSHOT:zip