### PR TITLE
Fix issue where enclosing class references are not correctly updated

### DIFF
--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/data/xformme/Sample_OuterClass.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/data/xformme/Sample_OuterClass.java
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package transformer.test.data.xformme;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class Sample_OuterClass {
+
+    protected AtomicBoolean changed = new AtomicBoolean();
+
+    public void run() {
+        final ActionListener al = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                changed.set(true);
+            }
+        };
+    }
+
+}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
@@ -553,19 +553,32 @@ public class ClassActionImpl extends ActionImpl {
 				}
 			}
 
-			case EnclosingMethodAttribute.NAME : {
-				EnclosingMethodAttribute attribute = (EnclosingMethodAttribute) attr;
-				String inputDescriptor = attribute.method_descriptor;
-				if (inputDescriptor == null) {
-					return null;
-				}
-				String outputDescriptor = transformDescriptor(inputDescriptor);
-				if (outputDescriptor == null) {
-					return null;
-				} else {
-					return new EnclosingMethodAttribute(attribute.class_name, attribute.method_name, outputDescriptor);
-				}
-			}
+			case EnclosingMethodAttribute.NAME: {
+                EnclosingMethodAttribute attribute = (EnclosingMethodAttribute) attr;
+
+                String inputDescriptor = attribute.method_descriptor;
+
+                String className = transformBinaryType(attribute.class_name);
+
+                if ( inputDescriptor == null && className == null) {
+                    return null;
+                }
+
+                String outputDescriptor = null;
+
+                if (inputDescriptor != null) {
+                    outputDescriptor = transformDescriptor(inputDescriptor);
+                }
+
+                if ( outputDescriptor == null  && className == null) {
+                    return null;
+                }
+
+                return new EnclosingMethodAttribute(
+                        className == null ? attribute.class_name : className,
+                        attribute.method_name,
+                        outputDescriptor == null ? inputDescriptor : outputDescriptor);
+            }
 
 			case StackMapTableAttribute.NAME : {
 				StackMapTableAttribute inputAttribute = (StackMapTableAttribute) attr;


### PR DESCRIPTION
There are some cases where a class A encloses another class B, and B makes a reference to A, the reference may not be correctly re-written.