### PR TITLE
build: Use passphrase in maven

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -56,7 +56,6 @@ jobs:
       uses: crazy-max/ghaction-import-gpg@v2
       env:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     - name: GPG key information
       if: (steps.import_gpg.outcome == 'success')
       run: |
@@ -71,3 +70,4 @@ jobs:
       env:
         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,7 @@
 			<properties>
 				<skipTests>true</skipTests>
 				<invoker.skip>true</invoker.skip>
+				<gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
 			</properties>
 			<build>
 				<plugins>


### PR DESCRIPTION
For some reason, the passphrase could not be set into the gpg-agent.
So we try to use it in the maven-gpg-plugin.
