### PR TITLE
61 Fix issue where service loader files can become corrupted

### DIFF
--- a/org.eclipse.transformer.cli/pom.xml
+++ b/org.eclipse.transformer.cli/pom.xml
@@ -89,6 +89,14 @@
 			<groupId>jakarta.management.j2ee</groupId>
 			<artifactId>jakarta.management.j2ee-api</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap</groupId>
+			<artifactId>shrinkwrap-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap</groupId>
+			<artifactId>shrinkwrap-impl-base</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestLoad.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestLoad.java
@@ -63,6 +63,7 @@ public class TestLoad {
 		}
 	}
 
+	public static final String		COMPLEX_RESOURCE_PATH	= "transformer/test/data/complex.properties";
 	public static final String		SIMPLE_RESOURCE_PATH	= "transformer/test/data/simple.resource";
 	public static final String[]	SIMPLE_RESOURCE_LINES	= {
 		"Simple Resource 1", "Simple Resource 2"

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformServiceConfig.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformServiceConfig.java
@@ -11,6 +11,8 @@
 
 package transformer.test;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
@@ -19,17 +21,30 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.TransformProperties;
 import org.eclipse.transformer.action.BundleData;
+import org.eclipse.transformer.action.impl.CompositeActionImpl;
+import org.eclipse.transformer.action.impl.JarActionImpl;
+import org.eclipse.transformer.action.impl.PropertiesActionImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
 import org.eclipse.transformer.action.impl.ServiceLoaderConfigActionImpl;
 import org.eclipse.transformer.action.impl.SignatureRuleImpl;
+import org.eclipse.transformer.util.FileUtils;
 import org.eclipse.transformer.util.InputStreamData;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import transformer.test.util.CaptureLoggerImpl;
+
+import static transformer.test.TestLoad.COMPLEX_RESOURCE_PATH;
 
 public class TestTransformServiceConfig extends CaptureTest {
 
@@ -124,6 +139,7 @@ public class TestTransformServiceConfig extends CaptureTest {
 
 	public ServiceLoaderConfigActionImpl	jakartaServiceAction;
 	public ServiceLoaderConfigActionImpl	javaxServiceAction;
+	public JarActionImpl					jarJavaxServiceAction;
 
 	public ServiceLoaderConfigActionImpl getJakartaServiceAction() {
 		if (jakartaServiceAction == null) {
@@ -149,6 +165,27 @@ public class TestTransformServiceConfig extends CaptureTest {
 		return javaxServiceAction;
 	}
 
+	public JarActionImpl getJarJavaxServiceAction() {
+		if (jarJavaxServiceAction == null) {
+			CaptureLoggerImpl useLogger = getCaptureLogger();
+
+			Map<String, String> invertedRenames = TransformProperties.invert(getPackageRenames());
+
+			CompositeActionImpl useRootAction = new CompositeActionImpl(useLogger, false, false, createBuffer(),
+				createSelectionRule(useLogger, Collections.emptySet(), getExcludes()),
+				createSignatureRule(useLogger, invertedRenames, null, null, null));
+
+			jarJavaxServiceAction = new JarActionImpl(useLogger, false, false, createBuffer(),
+				createSelectionRule(useLogger, Collections.emptySet(), getExcludes()),
+				createSignatureRule(useLogger, invertedRenames, null, null, null));
+
+			jarJavaxServiceAction.addAction(useRootAction.addUsing(PropertiesActionImpl::new));
+			jarJavaxServiceAction.addAction(useRootAction.addUsing(ServiceLoaderConfigActionImpl::new));
+		}
+
+		return jarJavaxServiceAction;
+	}
+
 	@Test
 	public void testJakartaTransform() throws IOException, TransformException {
 		ServiceLoaderConfigActionImpl jakartaAction = getJakartaServiceAction();
@@ -167,6 +204,51 @@ public class TestTransformServiceConfig extends CaptureTest {
 																										// transformed
 		verifyTransform(javaxAction, JAKARTA_SAMPLE_READER_SERVICE_PATH, JAVAX_SAMPLE_READER_LINES); // Transformed
 		verifyTransform(javaxAction, JAKARTA_SAMPLE_READER_SERVICE_PATH, JAVAX_SAMPLE_READER_LINES); // Transformed
+	}
+
+	@Test
+	public void testInputLength() throws IOException, TransformException {
+
+		/*
+		   This test is to ensure that the inputlength parameter in ServiceLoaderConfigActionImpl is used.
+		   When processing using a ContainerAction, the data passed in may "leak" other data from other files.
+		   The resulting transformed service file is corrupt.
+		 */
+
+		final File inputJarFile = File.createTempFile("sample", ".jar");
+		final File outputJarFile = File.createTempFile("sample_output", ".jar");
+		outputJarFile.delete();
+		inputJarFile.deleteOnExit();
+
+		final JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class);
+		javaArchive.add(new ClassLoaderAsset(COMPLEX_RESOURCE_PATH), "complex.properties");
+		javaArchive.add(new ClassLoaderAsset(JAKARTA_SAMPLE_READER_SERVICE_PATH), "META-INF/services/jakarta.sample.Reader");
+		javaArchive.as(ZipExporter.class).exportTo(inputJarFile, true);
+
+		final JarActionImpl jarJavaxServiceAction = getJarJavaxServiceAction();
+		jarJavaxServiceAction.apply("test.jar", inputJarFile, outputJarFile);
+
+		final String[] expectedLines = new String[] { "# Sample reader", "", "javax.sample.ReaderImpl" };
+
+		Assertions.assertTrue(outputJarFile.exists());
+		outputJarFile.deleteOnExit();
+
+		boolean found = false;
+		final ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(outputJarFile));
+		ZipEntry inputEntry;
+		while ((inputEntry = zipInputStream.getNextEntry()) != null) {
+			final String inputName = inputEntry.getName();
+			final long inputLength = inputEntry.getSize();
+
+			if ("META-INF/services/javax.sample.Reader".equals(inputName)) {
+				found = true;
+
+				final List<String> lines = TestUtils.loadLines(zipInputStream);
+				TestUtils.verify(inputName, expectedLines, lines);
+			}
+		}
+
+		Assertions.assertTrue(found);
 	}
 
 	protected void verifyTransform(ServiceLoaderConfigActionImpl action, String inputName, String[] expectedLines)

--- a/org.eclipse.transformer.cli/src/test/resources/transformer/test/data/complex.properties
+++ b/org.eclipse.transformer.cli/src/test/resources/transformer/test/data/complex.properties
@@ -1,0 +1,12 @@
+#Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque at lectus libero. Quisque at diam sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla in sollicitudin mauris. Donec suscipit lorem vel venenatis blandit. Ut convallis, massa sit amet pretium bibendum, elit felis suscipit elit, congue scelerisque sem felis nec augue. Aenean malesuada ornare accumsan.
+#
+#Mauris vitae convallis odio. Quisque sagittis dictum dignissim. Sed viverra neque in felis faucibus, at eleifend dolor aliquam. Quisque feugiat rutrum nisi at pharetra. Aenean laoreet, nisi sit amet placerat finibus, est nisi lobortis felis, et placerat odio felis et tortor. Pellentesque blandit justo tellus, ac posuere risus fringilla a. Phasellus feugiat velit et risus convallis finibus. Quisque lobortis tellus urna, aliquet tempor nunc blandit ultricies. Praesent id erat ullamcorper, pretium ligula facilisis, ultrices quam. Morbi laoreet orci a nulla fringilla pretium id at elit.
+#
+#Donec convallis ex ut cursus tempus. Pellentesque ornare, eros sed efficitur porta, erat velit consectetur arcu, non cursus tortor ipsum non magna. Mauris tempus nunc a erat fermentum mattis. Pellentesque et turpis tempus, interdum nunc vitae, tincidunt arcu. In vel nisl dui. Nulla euismod scelerisque auctor. Etiam sagittis sagittis leo, vitae convallis mi.
+#
+#Proin ultricies, tellus ullamcorper scelerisque mollis, enim tellus facilisis massa, eu maximus neque quam at dui. Pellentesque cursus nisi libero, a lobortis lorem tempor sit amet. Nunc aliquam egestas libero eu egestas. Duis interdum purus ut semper vehicula. Sed augue ligula, scelerisque at iaculis ac, mattis at lacus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Quisque eu luctus tellus, at faucibus mauris. Sed leo enim, bibendum eu congue ut, blandit a purus. Mauris nisl sem, malesuada nec enim ac, lacinia faucibus risus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Cras ultricies, magna in euismod venenatis, eros magna posuere est, vitae condimentum elit est sit amet nulla.
+#
+#Aliquam auctor vitae mauris sit amet euismod. Sed cursus sem velit, ac aliquet odio facilisis in. Curabitur at lacinia lectus, vel viverra massa. Aenean ex nunc, pulvinar vitae rhoncus at, eleifend nec odio. Sed in diam ac mi bibendum dictum. Nullam id orci accumsan urna fermentum tincidunt suscipit eu leo. Donec ut pellentesque turpis, ut tempor leo.
+
+
+test=jakarta.sample.ReaderImpl

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
@@ -113,7 +113,7 @@ public class ServiceLoaderConfigActionImpl extends ActionImpl {
 		}
 		setResourceNames(inputName, outputName);
 
-		InputStream inputStream = new ByteArrayInputStream(inputBytes);
+		InputStream inputStream = new ByteArrayInputStream(inputBytes,  0, inputLength);
 		InputStreamReader inputReader;
 		try {
 			inputReader = new InputStreamReader(inputStream, "UTF-8");
@@ -124,7 +124,7 @@ public class ServiceLoaderConfigActionImpl extends ActionImpl {
 
 		BufferedReader reader = new BufferedReader(inputReader);
 
-		ByteArrayOutputStream outputStream = new ByteArrayOutputStream(inputBytes.length);
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream(inputLength);
 		OutputStreamWriter outputWriter;
 		try {
 			outputWriter = new OutputStreamWriter(outputStream, "UTF-8");

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 		<assertj.version>3.16.1</assertj.version>
 		<!-- Reproducible build -->
 		<project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
+		<shrinkwrap.version>1.2.6</shrinkwrap.version>
 	</properties>
 
 	<modules>
@@ -424,6 +425,18 @@
 				<groupId>jakarta.management.j2ee</groupId>
 				<artifactId>jakarta.management.j2ee-api</artifactId>
 				<version>1.1.4</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.shrinkwrap</groupId>
+				<artifactId>shrinkwrap-api</artifactId>
+				<version>${shrinkwrap.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.shrinkwrap</groupId>
+				<artifactId>shrinkwrap-impl-base</artifactId>
+				<version>${shrinkwrap.version}</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
This addresses issue #61. The fix simply ensures that the inputLength is taken into account when reading into a ByteArrayInputStream.

I've included a test with two resources in a jar file, and processing them with a Jar action configured to work on both properties files and service loader files.

Signed-off-by: Jonathan Gallimore <jgallimore@tomitribe.com>