### PR TITLE
Fixes for Issues #43 and #44

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -144,3 +144,33 @@ javax.ejb.TimerService=jakarta.ejb.TimerService
 **Description**: Updates target files, reading these as UTF-8, line delimited, files.  Select update values (a table of initial and final text values) based on file name patterns.
 
 **Used by**: Text action
+
+### Case: Per class constant string update
+
+**Command line argument**: -tp, --per-class-constant
+
+**Property format**: Two tiers of property files are used.  The first tier maps class files to second tier files.  The second tier maps initial text values to final text values.
+
+For example:
+
+~~~
+jakarta-per-class-constant-master.properties
+~~~
+
+~~~
+org/apache/jasper/compiler/Generator.class=jsp-compiler.properties
+~~~
+
+~~~
+jsp-compiler.properties
+~~~
+
+~~~
+javax.servlet=jakarta.servlet
+~~~
+
+**Wildcard support**: None
+
+**Description**: Updates target classes. All occurrences of mapping keys present in constant strings are replaced with mapping values. 
+
+**Used by**: Class action

--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/jakarta/JakartaTransformer.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/jakarta/JakartaTransformer.java
@@ -36,6 +36,7 @@ public class JakartaTransformer {
 	public static final String	DEFAULT_BUNDLES_REFERENCE		= "jakarta-bundles.properties";
 	public static final String	DEFAULT_DIRECT_REFERENCE		= "jakarta-direct.properties";
 	public static final String	DEFAULT_MASTER_TEXT_REFERENCE	= "jakarta-text-master.properties";
+	public static final String	DEFAULT_PER_CLASS_CONSTANT_MASTER_REFERENCE	= "jakarta-per-class-constant-master.properties";
 
 	public static Map<Transformer.AppOption, String> getOptionDefaults() {
 		HashMap<Transformer.AppOption, String> optionDefaults = new HashMap<>();
@@ -45,6 +46,7 @@ public class JakartaTransformer {
 		optionDefaults.put(AppOption.RULES_BUNDLES, DEFAULT_BUNDLES_REFERENCE);
 		optionDefaults.put(AppOption.RULES_DIRECT, DEFAULT_DIRECT_REFERENCE);
 		optionDefaults.put(AppOption.RULES_MASTER_TEXT, DEFAULT_MASTER_TEXT_REFERENCE);
+		optionDefaults.put(AppOption.RULES_PER_CLASS_CONSTANT, DEFAULT_PER_CLASS_CONSTANT_MASTER_REFERENCE);
 
 		return optionDefaults;
 	}

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/CaptureTest.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/CaptureTest.java
@@ -61,8 +61,10 @@ public class CaptureTest {
 	}
 
 	public SignatureRuleImpl createSignatureRule(Logger useLogger, Map<String, String> usePackageRenames,
-		Map<String, String> usePackageVersions, Map<String, BundleData> bundleData, Map<String, String> directStrings) {
+		Map<String, String> usePackageVersions, Map<String, BundleData> bundleData, Map<String, String> directStrings, 
+		Map<String, Map<String,String>> perClass) {
 
-		return new SignatureRuleImpl(useLogger, usePackageRenames, usePackageVersions, bundleData, null, directStrings);
+		return new SignatureRuleImpl(useLogger, usePackageRenames, usePackageVersions, 
+					bundleData, null, directStrings, perClass);
 	}
 }

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformManifest.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformManifest.java
@@ -207,7 +207,7 @@ public class TestTransformManifest extends CaptureTest {
 
 			jakartaManifestAction = new ManifestActionImpl(useLogger, false, false, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
-					getPackageRenames(), getPackageVersions(), getBundleUpdates(), null, getDirectStrings()),
+					getPackageRenames(), getPackageVersions(), getBundleUpdates(), null, getDirectStrings(), Collections.emptyMap()),
 				ManifestActionImpl.IS_MANIFEST);
 		}
 		return jakartaManifestAction;
@@ -221,7 +221,7 @@ public class TestTransformManifest extends CaptureTest {
 
 			jakartaFeatureAction = new ManifestActionImpl(useLogger, false, false, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
-				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, null, null),
+				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, null, null, Collections.emptyMap()),
 				ManifestActionImpl.IS_FEATURE);
 		}
 
@@ -238,7 +238,7 @@ public class TestTransformManifest extends CaptureTest {
 
 			jakartaManifestActionTx = new ManifestActionImpl(useLogger, false, false, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
-					getPackageRenames(), getPackageVersions(), getBundleUpdatesTx(), null, getDirectStrings()),
+					getPackageRenames(), getPackageVersions(), getBundleUpdatesTx(), null, getDirectStrings(), Collections.emptyMap()),
 				ManifestActionImpl.IS_MANIFEST);
 		}
 		return jakartaManifestActionTx;
@@ -633,7 +633,7 @@ public class TestTransformManifest extends CaptureTest {
 
 			manifestAction_test = new ManifestActionImpl_Test(useLogger, false, false, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
-				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, null, null),
+				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, null, null, Collections.emptyMap()),
 				ManifestActionImpl.IS_MANIFEST);
 		}
 

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformPropertiesFile.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformPropertiesFile.java
@@ -37,7 +37,7 @@ public class TestTransformPropertiesFile extends CaptureTest {
 
 	public SignatureRuleImpl createSignatureRule(CaptureLoggerImpl useLogger, Map<String, String> packageRename) {
 
-		return new SignatureRuleImpl(useLogger, packageRename, null, null, null, null);
+		return new SignatureRuleImpl(useLogger, packageRename, null, null, null, null, Collections.emptyMap());
 	}
 
 	public static final String	JAKARTA_SERVLET	= "jakarta.servlet";

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformServiceConfig.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformServiceConfig.java
@@ -56,7 +56,7 @@ public class TestTransformServiceConfig extends CaptureTest {
 	public SignatureRuleImpl createSignatureRule(CaptureLoggerImpl useLogger, Map<String, String> usePackageRenames,
 		Map<String, String> usePackageVersions, Map<String, BundleData> bundleData, Map<String, String> directStrings) {
 
-		return new SignatureRuleImpl(useLogger, usePackageRenames, usePackageVersions, bundleData, null, directStrings);
+		return new SignatureRuleImpl(useLogger, usePackageRenames, usePackageVersions, bundleData, null, directStrings, Collections.emptyMap());
 	}
 
 	//

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformXML.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformXML.java
@@ -90,7 +90,7 @@ public class TestTransformXML extends CaptureTest {
 
 			textAction = new TextActionImpl(useLogger, false, false, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
-				new SignatureRuleImpl(useLogger, null, null, null, getMasterXmlUpdates(), null));
+				new SignatureRuleImpl(useLogger, null, null, null, getMasterXmlUpdates(), null, Collections.emptyMap()));
 		}
 
 		return textAction;

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/data/Sample_PerClassConstant.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/data/Sample_PerClassConstant.java
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package transformer.test.data;
+
+public class Sample_PerClassConstant {
+
+	static {
+		System.out.println("javax.servlet.foo.bar=something,javax.servlet.foo.bar2=else");
+	}
+}

--- a/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
+++ b/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
@@ -58,6 +58,9 @@ public class TransformMojo extends AbstractMojo {
 	@Parameter(property = "transformer-plugin.direct", defaultValue = "")
 	private String				rulesDirectUri;
 
+	@Parameter(property = "transformer-plugin.per-class-constant", defaultValue = "")
+	private String rulesPerClassConstantUri;
+
 	@Parameter(property = "transformer-plugin.xml", defaultValue = "")
 	private String				rulesXmlsUri;
 
@@ -169,6 +172,8 @@ public class TransformMojo extends AbstractMojo {
 			isEmpty(rulesDirectUri) ? "jakarta-direct.properties" : rulesDirectUri);
 		optionDefaults.put(Transformer.AppOption.RULES_MASTER_TEXT,
 			isEmpty(rulesXmlsUri) ? "jakarta-text-master.properties" : rulesXmlsUri);
+		optionDefaults.put(Transformer.AppOption.RULES_PER_CLASS_CONSTANT,
+			isEmpty(rulesPerClassConstantUri) ? "jakarta-per-class-constant-master.properties" : rulesPerClassConstantUri);
 		return optionDefaults;
 	}
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/SignatureRule.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/SignatureRule.java
@@ -143,4 +143,6 @@ public interface SignatureRule {
 
 	String getDirectString(String initialValue);
 
+	String getConstantString(String initialValue, String clazz);
+
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
@@ -294,6 +294,10 @@ public abstract class ActionImpl implements Action {
 		return getSignatureRule().getDirectString(initialValue);
 	}
 
+	public String transformConstantString(String initialValue, String className) {
+		return getSignatureRule().getConstantString(initialValue, className);
+	}
+
 	//
 
 	public abstract String getAcceptExtension();

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
@@ -950,6 +950,10 @@ public class ClassActionImpl extends ActionImpl {
 				if (outputString == null) {
 					transformCase = "direct";
 					outputString = transformDirectString(inputString);
+					if (outputString == null) {
+						transformCase = "direct per class";
+						outputString = transformConstantString(inputString, inputName);
+					}
 				}
 			}
 			if (outputString == null) {
@@ -1115,6 +1119,14 @@ public class ClassActionImpl extends ActionImpl {
 			AnnotationInfo annotationValue = (AnnotationInfo) inputValue;
 			return transform(annotationValue, AnnotationInfo::new);
 
+		} else if (inputValue instanceof String) {
+			String inputString = (String) inputValue;
+			String outputString = transformDirectString(inputString);
+			if (outputString == null) {
+				outputString = transformConstantString(inputString, inputName);
+			}
+			return outputString;
+
 		} else if (inputValue instanceof Object[]) {
 			Object[] inputElementValues = ((Object[]) inputValue);
 			Object[] outputElementValues = null;
@@ -1250,6 +1262,10 @@ public class ClassActionImpl extends ActionImpl {
 							if (outputUtf8 == null) {
 								transformCase = "Direct";
 								outputUtf8 = transformDirectString(inputUtf8);
+								if (outputUtf8 == null) {
+									transformCase = "Direct per class";
+									outputUtf8 = transformConstantString(inputUtf8, inputName);
+								}
 							}
 						}
 					}
@@ -1278,6 +1294,10 @@ public class ClassActionImpl extends ActionImpl {
 						if (outputString == null) {
 							transformCase = "Direct";
 							outputString = transformDirectString(inputString);
+							if (outputString == null) {
+								transformCase = "Direct per class";
+								outputString = transformConstantString(inputString, inputName);
+							}
 						}
 					}
 					if (outputString != null) {

--- a/org.eclipse.transformer/src/test/java/org/eclipse/transformer/action/impl/ClassActionTest.java
+++ b/org.eclipse.transformer/src/test/java/org/eclipse/transformer/action/impl/ClassActionTest.java
@@ -117,7 +117,7 @@ public class ClassActionTest {
 		renames.put("original.main", "transformed.main");
 		Action classAction = new ClassActionImpl(logger, false, false, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
-			new SignatureRuleImpl(logger, renames, null, null, null, null));
+			new SignatureRuleImpl(logger, renames, null, null, null, null, Collections.emptyMap()));
 		classAction.apply(testName, inputStream, inputStream.available(), outputStream);
 
 		ClassFile transformed = ClassFile.parseClassFile(ByteBufferDataInput.wrap(outputStream.toByteBuffer()));
@@ -209,7 +209,7 @@ public class ClassActionTest {
 		renames.put("original.member", "transformed.member");
 		Action classAction = new ClassActionImpl(logger, false, false, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
-			new SignatureRuleImpl(logger, renames, null, null, null, null));
+			new SignatureRuleImpl(logger, renames, null, null, null, null, Collections.emptyMap()));
 		classAction.apply(testName, inputStream, inputStream.available(), outputStream);
 
 		ClassFile transformed = ClassFile.parseClassFile(ByteBufferDataInput.wrap(outputStream.toByteBuffer()));
@@ -252,7 +252,7 @@ public class ClassActionTest {
 		renames.put("original.result", "transformed.result");
 		Action classAction = new ClassActionImpl(logger, false, false, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
-			new SignatureRuleImpl(logger, renames, null, null, null, null));
+			new SignatureRuleImpl(logger, renames, null, null, null, null, Collections.emptyMap()));
 		classAction.apply(testName, inputStream, inputStream.available(), outputStream);
 
 		ClassFile transformed = ClassFile.parseClassFile(ByteBufferDataInput.wrap(outputStream.toByteBuffer()));


### PR DESCRIPTION
Constant string transformation (#44) and on fix for Annotation Element value of type String (#43).

A user would define a master index such as:
org/jboss/as/jaxrs/JaxrsAnnotations$Constants.class=jaxrs-annotations.properties
org/apache/jasper/compiler/Generator.class=jsp-compiler.properties
org/jboss/as/weld/CdiAnnotations$Constants.class=cdi-annotations.properties

Each properties file would then contain specific mapping for the class.
Note that the transformation also looks inside complex String to replace parts.

Added unit test.

Signed-off-by: JF Denise <jdenise@redhat.com>

