### PR TITLE
ci: Only use settings.xml for publishing

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./mvnw --batch-mode deploy "$@"
+./mvnw --batch-mode --settings settings.xml deploy "$@"

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -42,9 +42,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-        server-id: ossrh
-        server-username: OSSRH_USERNAME
-        server-password: OSSRH_TOKEN
     - name: Build
       id: build
       continue-on-error: ${{ matrix.experimental }}
@@ -52,7 +49,7 @@ jobs:
         ./.github/scripts/build.sh ${{ matrix.mavenopts }}
     - name: Import GPG key
       id: import_gpg
-      if: (matrix.canonical)
+      if: (matrix.canonical && (steps.build.outcome == 'success'))
       uses: mbarbero/ghaction-import-gpg@subkeys
       env:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,11 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${env.OSSRH_USERNAME}</username>
+      <password>${env.OSSRH_TOKEN}</password>
+    </server>
+  </servers>
+  <mirrors/>
+</settings>


### PR DESCRIPTION
This avoids any issue with a settings for ossrh having invalid
credentials on a branch or fork build.
