### PR TITLE
85 multi properties

### DIFF
--- a/org.eclipse.transformer.cli/src/test/data/multi/MANIFEST.MF
+++ b/org.eclipse.transformer.cli/src/test/data/multi/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+DynamicImport-Package: javax.package0;version="0.0.0",javax.package1;v
+ ersion="1.0.0",javax.package2;version="2.0.0",javax.package3;version=
+ "3.0.0",javax.package4;version="4.0.0",javax.package5;version="5.0.0"
+ ,javax.package6;version="6.0.0",javax.package7;version="7.0.0"

--- a/org.eclipse.transformer.cli/src/test/data/multi/tier0.renames.properties
+++ b/org.eclipse.transformer.cli/src/test/data/multi/tier0.renames.properties
@@ -1,0 +1,4 @@
+javax.package0=jakarta.package0
+javax.package1=jakarta.package1
+javax.package2=jakarta.package2
+javax.package3=jakarta.package3

--- a/org.eclipse.transformer.cli/src/test/data/multi/tier0.versions.properties
+++ b/org.eclipse.transformer.cli/src/test/data/multi/tier0.versions.properties
@@ -1,0 +1,4 @@
+jakarta.package0=0.0.1
+jakarta.package1=1.0.1
+jakarta.package2=2.0.1
+jakarta.package3=3.0.1

--- a/org.eclipse.transformer.cli/src/test/data/multi/tier1.renames.properties
+++ b/org.eclipse.transformer.cli/src/test/data/multi/tier1.renames.properties
@@ -1,0 +1,2 @@
+javax.package1=jakarta.package11
+javax.package4=jakarta.package4

--- a/org.eclipse.transformer.cli/src/test/data/multi/tier1.versions.properties
+++ b/org.eclipse.transformer.cli/src/test/data/multi/tier1.versions.properties
@@ -1,0 +1,2 @@
+jakarta.package11=1.1.1
+jakarta.package4=4.1.1

--- a/org.eclipse.transformer.cli/src/test/data/multi/tier2.renames.properties
+++ b/org.eclipse.transformer.cli/src/test/data/multi/tier2.renames.properties
@@ -1,0 +1,2 @@
+javax.package2=jakarta.package22
+javax.package5=jakarta.package5

--- a/org.eclipse.transformer.cli/src/test/data/multi/tier2.versions.properties
+++ b/org.eclipse.transformer.cli/src/test/data/multi/tier2.versions.properties
@@ -1,0 +1,2 @@
+jakarta.package22=2.1.1
+jakarta.package5=5.1.1

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestCommandLine.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestCommandLine.java
@@ -93,10 +93,4 @@ class TestCommandLine {
 		options.transform();
 		assertTrue((new File(outputFileName)).exists(), "output file not created");
 	}
-
-	// at
-	// org.eclipse.transformer.Transformer$TransformOptions.transform(Transformer.java:1255)
-	// at transformer.test.TestCommandLine.verifyAction(TestCommandLine.java:88)
-	// at
-	// transformer.test.TestCommandLine.testManifestActionAccepted(TestCommandLine.java:50)
 }

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformerBase.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformerBase.java
@@ -1,0 +1,272 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package transformer.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.transformer.Transformer;
+import org.eclipse.transformer.Transformer.TransformOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+public abstract class TestTransformerBase {
+
+	// TODO: This is currently used for input data and for output data.
+	//       Output data should be written to a build location, which is
+	//       much safer.
+
+	private static final String	DATA_DIR = "src/test/data";
+
+	public String getDataDir() {
+		return DATA_DIR;
+	}
+
+	private String currentDirectory = ".";
+
+	public String getCurrentDir() {
+		return currentDirectory;
+	}
+
+	//
+
+	@BeforeEach
+	public void setUp() {
+		currentDirectory = System.getProperty("user.dir");
+		System.out.println("setUp: Current directory is: [" + currentDirectory + "]");
+	}
+
+	/** Control parameter: Enable debug logging. */
+	public static final boolean DO_DEBUG_LOGGING = true;
+
+	/**
+	 * Run the transformer using java interfaces.
+	 *
+	 * Compose transformer options using the supplied parameters.
+	 *
+	 * Verify that the output file was created and that expected
+	 * log fragments are present in the transformer output log.
+	 *
+	 * Answer the raw bytes of the captured transformer log.
+	 *
+	 * @param inputFileName The file to be transformed.
+	 * @param outputFileName The transformation output file.
+	 * @param parms Additional transformation parameters.
+	 * @param enableDebugLogging Control parameter telling if debug
+	 *     logging is to be enabled.
+	 * @param expectedLogFragments Text which is expected to be present
+	 *     in the transformer log.
+	 *
+	 * @return The raw bytes of the transformer log.
+	 *
+	 * @throws Exception Thrown in case of a transformation error.
+	 *
+	 * @throws AssertionFailedError Thrown by an assertion failure.  This
+	 *     is a test failure, as opposed to a processing error.
+	 */
+	@Test
+	public byte[] runTransformer(
+		String inputFileName, String outputFileName,
+		String[] parms,
+		boolean enableDebugLogging,
+		String[] expectedLogFragments) throws Exception, AssertionFailedError {
+
+		ByteArrayOutputStream sysOutByteOutput = new ByteArrayOutputStream();
+
+		PrintStream sysOutOutput = new PrintStream(sysOutByteOutput);
+
+		int argCount = 3 + parms.length + ( enableDebugLogging ? 2 : 0 );
+
+		String[] args = new String[argCount];
+		args[0] = inputFileName;
+		args[1] = outputFileName;
+		args[2] = "-o"; // Overwrite
+
+		for ( int parmNo = 0; parmNo < parms.length; parmNo++ ) {
+			args[3 + parmNo] = parms[parmNo];
+		}
+
+		if ( enableDebugLogging ) {
+			args[argCount - 2] = "-ll";
+			args[argCount - 1] = "debug";
+		}
+
+		Transformer t = new Transformer(sysOutOutput, sysOutOutput);
+
+		t.setArgs(args);
+		t.setParsedArgs();
+
+		TransformOptions options = t.createTransformOptions();
+		options.setLogging();
+
+		assertTrue( options.setInput(), "options.setInput() failed" );
+		assertEquals( inputFileName, options.getInputFileName(),
+			"input file name is not correct [ " + options.getInputFileName() + " ]" );
+
+		assertTrue( options.setOutput(), "options.setOutput() failed" );
+		assertEquals( outputFileName, options.getOutputFileName(),
+			"output file name is not correct [ " + options.getOutputFileName() + " ]" );
+
+		assertTrue(options.setRules(), "options.setRules() failed");
+		assertTrue(options.acceptAction(), "options.acceptAction() failed");
+
+		options.transform();
+
+		sysOutOutput.close();
+
+		byte[] sysOutBytes = sysOutByteOutput.toByteArray();
+		ByteArrayInputStream sysOutByteInput = new ByteArrayInputStream(sysOutBytes, 0, sysOutBytes.length); 
+		verifyLog("property option logging", expectedLogFragments, sysOutByteInput);
+		// throws IOException, AssertionFailedError
+
+		assertTrue( (new File(outputFileName)).exists(), "output file not created" );
+
+		return sysOutBytes;
+	}
+
+	//
+
+	/**
+	 * Standard log fragment for multi-property logging.
+	 *
+	 * @param key The key that was updated.
+	 * @param value1 The initial value.
+	 * @param value2 The final, updated, value.
+	 * 
+	 * @return Update replacement log fragment text. 
+	 */
+	public static String logReplacementFragment(String key, String value1, String value2) {
+		return "key [ " + key + " ] replaces value [ " + value1 + " ] with [ " + value2 + " ]";
+	}
+
+	//
+
+	/**
+	 * Verify log text using an array of text fragments.
+	 * 
+	 * If verification fails, display the generated validation failure
+	 * messages, and throw an error.
+	 *
+	 * If verification succeeds, display a success message. 
+	 *
+	 * Verification is performed by {@link #verifyLog(String[], InputStream)}.
+	 * 
+	 * @param description A description to display with verification results.
+	 * @param expectedFragments Text fragments which are expected in the
+	 *     captured log text.
+	 * @param logStream A stream containing the captured log text.
+	 *
+	 * @throws IOException Thrown in case of a failure to read the log stream.
+	 *
+	 * @throws AssertionFailedError Thrown if verification fails.
+	 */
+	public void verifyLog(String description, String[] expectedFragments, InputStream logStream)
+		throws IOException, AssertionFailedError {
+
+		List<String> errors = verifyLog(expectedFragments, logStream); // throws IOException
+		processErrors(description, errors); // throws AssertionFailedError
+	}
+
+	/**
+	 * Verify log text using an array of text fragments.
+	 *
+	 * Currently, each fragment must occur exactly once.
+	 * 
+	 * Generate an error message for each missing text fragment, and for
+	 * each text fragment which is detected more than once.
+	 * 
+	 * @param expectedFragments The text fragments which are expected to be present
+	 *     in the log stream
+	 * @param logStream A stream containing captured log output.
+	 *
+	 * @return The list of error obtained whilst searching the log text for
+	 *     the text fragments.
+	 *
+	 * @throws IOException Thrown in case of an error reading the log stream.
+	 */
+	public List<String> verifyLog(String[] expectedFragments, InputStream logStream) throws IOException {
+		List<String> errors = new ArrayList<String>();
+
+		BufferedReader logReader = new BufferedReader( new InputStreamReader(logStream) );
+
+		int expectedMatches =  expectedFragments.length;
+		boolean[] matches = new boolean[expectedMatches];
+		
+		String nextLine;
+		while ( (nextLine = logReader.readLine()) != null ) { // throws IOException
+			// System.out.println("Log [ " + nextLine + " ]");
+
+			for ( int fragmentNo = 0; fragmentNo < expectedMatches; fragmentNo++ ) {
+				String fragment = expectedFragments[fragmentNo];
+				if ( !nextLine.contains(fragment) ) {
+					continue;
+				}
+				
+				if ( matches[fragmentNo] ) {
+					errors.add("Extra occurrence of log text [ " + fragment + " ]");
+				} else {
+					System.out.println("Match on log fragment [ " + fragment + " ]");
+					matches[fragmentNo] = true;
+				}
+			}
+		}
+		
+		for ( int fragmentNo = 0; fragmentNo < expectedMatches; fragmentNo++ ) {
+			if ( !matches[fragmentNo] ) {
+				errors.add("Missing occurrence of log text [ " + expectedFragments[fragmentNo] + " ]");
+			}
+		}
+		
+		return errors;
+	}
+
+	/**
+	 * Examine a collection of errors, and fail with an assertion error
+	 * if any errors are present.  Display the errors to <code>System.out</code>
+	 * before throwing the error.
+	 *
+	 * @param description A description to display with a failure message if
+	 *     errors are detected, and with a success message if no errors are
+	 *     present.
+	 * @param errors The errors which are to be examined.
+	 *
+	 * @throws AssertionFailedError Thrown if any errors are present.
+	 */
+	public void processErrors(String description, List<String> errors)
+		throws AssertionFailedError {
+
+		if ( errors.isEmpty() ) {
+			System.out.println("Correct " + description);
+
+		} else { 
+			description = "Incorrect " + description;
+			System.out.println(description);
+			for ( String error : errors ) {
+				System.out.println(error);
+			}
+			fail(description);
+		}
+	}
+}

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformerMultiRenames.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformerMultiRenames.java
@@ -1,0 +1,233 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package transformer.test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+public class TestTransformerMultiRenames extends TestTransformerBase {
+
+	private static final String DATA_DIR = "src/test/data/multi";
+
+	public String getDataDir() {
+		return DATA_DIR;
+	}
+
+	//
+
+	// Renames and version assignments are linked.
+	//
+	// This test overlays both, and verifies that updates were made correctly
+	// according to the test plan.
+
+	// RULES_RENAMES("tr", "renames", "Transformation package renames URL", OptionSettings.HAS_ARG,
+	//     !OptionSettings.HAS_ARGS, !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
+	// RULES_VERSIONS("tv", "versions", "Transformation package versions URL", OptionSettings.HAS_ARG,
+	//     !OptionSettings.HAS_ARGS, !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
+
+	// Test plan:
+	//
+	// Initial:                               Final:
+	//
+	// javax.package0;version="0.0.0"         jakarta.package0;version="0.0.1"
+	// javax.package1;version="1.0.0"         jakarta.package0;version="1.1.1"
+	// javax.package2;version="2.0.0"         jakarta.package0;version="2.1.1"
+	// javax.package3;version="3.0.0"         jakarta.package0;version="3.0.1"
+	// javax.package4;version="4.0.0"         jakarta.package0;version="4.1.1"
+	// javax.package5;version="5.0.0"         jakarta.package0;version="5.1.1"
+	// javax.package6;version="6.0.0"         javax.package0;version="6.0.0"
+	// javax.package7;version="7.0.0"         javax.package0;version="7.0.0"
+	//
+	// tier0: javax.package0=jakarta.package0
+	//        javax.package1=jakarta.package1
+	//        javax.package2=jakarta.package2
+	//        javax.package3=jakarta.package3
+	//
+	// tier1: javax.package1=jakarta.package11
+	//        javax.package4=jakarta.package4
+	//
+	// tier2: javax.package2=jakarta.package22
+	//        javax.package5=jakarta.package5
+	//
+	// tier0: jakarta.package0="0.0.1"
+	//        jakarta.package1="1.0.1"
+	//        jakarta.package2="2.0.1"
+	//        jakarta.package3="3.0.1"	
+	//
+	// tier1: jakarta.package11="1.1.1"
+	//        jakarta.package4="4.1.1"
+	//
+	// tier1: jakarta.package22="2.1.1"
+	//        jakarta.package5="5.1.1"
+	//
+	// "Merge of [ %s ] into [ %s], key [ %s] replaces value [ %s] with [ %s ]"
+	//
+	// " key [ " + k + " ] replaces value [ " + v1 + " ] with [ " + v2 + " ]" 	
+	
+	@Test
+	void testMultiRenames() throws Exception {
+		String inputFileName = DATA_DIR + '/' + "MANIFEST.MF";
+		String outputFileName = DATA_DIR + '/' + "OUTPUT_MANIFEST.MF";
+
+		verifyPackageVersions("initial package versions", inputFileName, initialPackageVersions );
+		// throws IOException, AssertionFailedError
+
+		String[] args = new String[] {
+			"-tr", DATA_DIR + '/' + "tier0.renames.properties",
+			"-tr", DATA_DIR + '/' + "tier1.renames.properties",
+			"-tr", DATA_DIR + '/' + "tier2.renames.properties",
+
+			"-tv", DATA_DIR + '/' + "tier0.versions.properties",
+			"-tv", DATA_DIR + '/' + "tier1.versions.properties",
+			"-tv", DATA_DIR + '/' + "tier2.versions.properties",
+		};
+		
+		byte[] logBytes = runTransformer(
+			inputFileName, outputFileName,
+			args,
+			DO_DEBUG_LOGGING,
+			getLogFragments() );
+
+		verifyPackageVersions("final package versions", outputFileName, finalPackageVersions);
+		// throws IOException, AssertionFailedError
+	}
+
+	//
+
+	public String[] getLogFragments() {
+		return new String[] {
+			logReplacementFragment("javax.package1", "jakarta.package1", "jakarta.package11"),
+			logReplacementFragment("javax.package2", "jakarta.package2", "jakarta.package22")
+		};
+	}
+
+	//
+
+	public static final Map<String, String> initialPackageVersions;
+	public static final Map<String, String> finalPackageVersions;
+
+	static {
+		initialPackageVersions = new HashMap<String, String>(8);
+
+		initialPackageVersions.put("javax.package0", "0.0.0");
+		initialPackageVersions.put("javax.package1", "1.0.0");
+		initialPackageVersions.put("javax.package2", "2.0.0");
+		initialPackageVersions.put("javax.package3", "3.0.0");
+		initialPackageVersions.put("javax.package4", "4.0.0");
+		initialPackageVersions.put("javax.package5", "5.0.0");
+		initialPackageVersions.put("javax.package6", "6.0.0");
+		initialPackageVersions.put("javax.package7", "7.0.0");
+
+		finalPackageVersions = new HashMap<String, String>(8);
+
+		finalPackageVersions.put("jakarta.package0", "0.0.1");
+		finalPackageVersions.put("jakarta.package11", "1.1.1");
+		finalPackageVersions.put("jakarta.package22", "2.1.1");
+		finalPackageVersions.put("jakarta.package3", "3.0.1");
+		finalPackageVersions.put("jakarta.package4", "4.1.1");
+		finalPackageVersions.put("jakarta.package5", "5.1.1");
+		finalPackageVersions.put("javax.package6", "6.0.0");
+		finalPackageVersions.put("javax.package7", "7.0.0");
+	}
+
+	public static final String TARGET_ATTRIBUTE_NAME = "DynamicImport-Package";
+
+	// "javax.package6;version=\"6.0.0\",javax.package7;version=\"7.0.0\""
+
+	public Map<String, String> loadPackageVersions(String description, String manifestPath) throws IOException {
+		Manifest manifest = new Manifest();
+
+		try ( InputStream manifestStream = new FileInputStream(manifestPath) ) { // throws IOException
+			manifest.read(manifestStream); // throws IOException
+		}
+
+		Map<String, String> packageData = new HashMap<String, String>();
+
+		String targetAttribute = manifest.getMainAttributes().getValue(TARGET_ATTRIBUTE_NAME);
+		System.out.println(description + " [ " + manifestPath + " ]:");
+		System.out.println("  [ " + targetAttribute + " ]");
+
+		StringTokenizer tokenizer = new StringTokenizer(targetAttribute, ",", false);
+		while ( tokenizer.hasMoreElements() ) {
+			String nextToken = tokenizer.nextToken();
+
+			int packageEnd = nextToken.indexOf(';');
+			String packageName = nextToken.substring(0, packageEnd);
+
+			int versionStart = nextToken.indexOf("version=\"") + "version=\"".length();
+			int versionEnd = nextToken.length() - 1; // -1 to omit the closing '"'
+
+			String version = nextToken.substring(versionStart, versionEnd);
+
+			System.out.println("  [ " + nextToken + " ]: [ " + packageName + " ] [ " + version + " ]");
+
+			packageData.put(packageName, version);
+		}
+
+		return packageData;
+	}
+
+	public void verifyPackageVersions(String description, String actualFileName, Map<String, String> expected)
+		throws IOException, AssertionFailedError {
+
+		List<String> errors = verifyPackageVersions(
+			loadPackageVersions(description, actualFileName),
+			expected );
+		// 'loadPackageVersions' throws IOException
+
+		processErrors(description, errors); // throws AssertionFailedError
+	}
+
+	public List<String> verifyPackageVersions(Map<String, String> actual, Map<String, String> expected) {
+		List<String> errors = new ArrayList<String>();
+
+		for ( Map.Entry<String, String> actualEntry : actual.entrySet() ) {
+			String actualName = actualEntry.getKey();
+			String actualVersion = actualEntry.getValue();
+
+			String expectedVersion = expected.get(actualName);
+
+			if ( expectedVersion == null ) {
+				errors.add("Extra actual: Package [ " + actualName + " ] version [ " + actualVersion + " ]");
+			} else if ( !actualVersion.equals(expectedVersion) ) {
+				errors.add("Incorrect actual: Package [ " + actualName + " ] version [ " + actualVersion + " ]; expected [ " + expectedVersion + " ]");
+			} else {
+				// OK
+			}
+		}
+
+		for ( Map.Entry<String, String> expectedEntry : expected.entrySet() ) {
+			String expectedName = expectedEntry.getKey();
+			String expectedVersion = expectedEntry.getValue();
+
+			String actualVersion = actual.get(expectedName);
+
+			if ( actualVersion == null ) {
+				errors.add("Missing expected: Package [ " + expectedName + " ] version [ " + expectedVersion + " ]");
+			} else {
+				// OK, or already detected
+			}
+		}
+
+		return errors;
+	}
+}

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformerMultiText.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestTransformerMultiText.java
@@ -1,0 +1,260 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package transformer.test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+// Initial:
+// The quick brown fox jumps over the lazy dog. 
+// text[x].ext[y] (x==0..7, y=0..7)
+//
+// tier0.master.properties:
+//   *.ext0=ext0.properties
+//     quick=slow
+//     lazy=happy
+//     The slow brown fox jumps over the happy dog.
+//   *.ext1=ext1.properties
+//     quick=fast
+//     brown=blue
+//     -- Not active
+//   *.ext2=ext2.properties
+//     fox=hen
+//     over=under
+//     -- Not active
+// tier1.master.properties:
+//   *.ext1=ext11.properties
+//     quick=lethargic
+//     lazy=energetic
+	//     The lethargic brown fox jumps over the energetic dog.
+//   *.ext4=ext4.properties
+//      jumps=walks
+//      dog=meadow
+// 	    The quick brown fox walks over the lazy meadow.";
+// tier2.master.properties:
+//   *.ext2=ext22.properties
+//      fox=elephant
+//      over=beside
+//      The quick brown elephant jumps beside the lazy dog.";
+//   *.ext5=ext5.properties
+//      jumps=strolls
+//      over=behind
+// 	    The quick brown fox strolls behind the lazy dog.
+
+public class TestTransformerMultiText extends TestTransformerBase {
+
+	private static final String DATA_DIR = "src/test/data/multi";
+
+	public String getDataDir() {
+		return DATA_DIR;
+	}
+
+	// Rules data ...
+
+	public static class TextRulesData {
+		public final String fileName;
+		public final String[] assignments;
+		
+		public TextRulesData(String fileName, String... assignments) {
+			this.fileName = fileName;
+			this.assignments = assignments;
+		}
+		
+		public void write(String dataDir) throws IOException {
+			try ( OutputStream outputStream = new FileOutputStream(dataDir + '/' + fileName, false) ) { // truncate
+				OutputStreamWriter outputWriter = new OutputStreamWriter(outputStream);
+
+				for ( String assignment : assignments ) {
+					outputWriter.write(assignment);
+					outputWriter.write('\n');
+				}
+				
+				outputWriter.flush();
+			}
+		}
+	}
+	
+	public static final String TIER0_MASTER_PROPERTIES = "tier0.master.properties"; 
+	public static final String TIER1_MASTER_PROPERTIES = "tier1.master.properties"; 
+	public static final String TIER2_MASTER_PROPERTIES = "tier2.master.properties"; 
+	
+	private static final TextRulesData[] RULES_DATA =
+		new TextRulesData[] {
+			new TextRulesData(TIER0_MASTER_PROPERTIES,
+				"*.ext0=ext0.properties",
+				"*.ext1=ext1.properties",
+				"*.ext2=ext2.properties"),
+			new TextRulesData("ext0.properties", "quick=slow", "lazy=happy"),
+			new TextRulesData("ext1.properties", "quick=fast", "brown=blue"),
+			new TextRulesData("ext2.properties", "fox=hen", "over=under"),
+
+			new TextRulesData("tier1.master.properties", "*.ext1=ext11.properties", "*.ext4=ext4.properties"),
+			new TextRulesData("ext11.properties", "quick=lethargic", "lazy=energetic"),
+			new TextRulesData("ext4.properties", "jumps=walks", "dog=meadow"),
+
+			new TextRulesData("tier2.master.properties", "*.ext2=ext22.properties", "*.ext5=ext5.properties"),
+			new TextRulesData("ext22.properties", "fox=elephant", "over=beside"),
+			new TextRulesData("ext5.properties", "jumps=strolls", "over=behind")
+		};
+
+	public static String[] getLogFragments() {
+		return new String[] { 
+			logReplacementFragment("*.ext1", "ext1.properties", "ext11.properties"), 
+			logReplacementFragment("*.ext2", "ext2.properties", "ext22.properties")
+		};
+	}
+
+	protected void writeRulesData(String dataDir) throws IOException{
+		for ( TextRulesData rulesData : RULES_DATA ) {
+			rulesData.write(dataDir); // throws IOException
+		}
+	}
+
+	// Input data ...
+
+	public static final String INPUT_TEXT =
+	    "The quick brown fox jumps over the lazy dog.";
+	
+	public static final int NUM_FILES = 8;
+	public static final int NUM_EXTS = 8;
+
+	protected String getExtension(int extNo) {
+		return ( '.' + "ext" + Integer.toString(extNo) );
+	}
+
+	protected String getInputName(int fileNo, int extNo) {
+		return "text" + Integer.toString(fileNo) + getExtension(extNo);
+	}
+
+	protected void writeInputData(String inputDir) throws IOException {
+		for ( int fileNo = 0; fileNo < NUM_FILES; fileNo++ ) {
+			for ( int extNo = 0; extNo < NUM_EXTS; extNo++ ) {
+				String inputName = getInputName(fileNo, extNo);
+				String inputPath = inputDir + '/' + inputName;
+				writeInputFile(inputPath); // throws IOException
+			}
+		}
+	}
+
+	protected void writeInputFile(String inputPath) throws IOException {
+		try ( OutputStream outputStream = new FileOutputStream(inputPath, true) ) { // throws FileNotFoundException
+			PrintWriter outputWriter = new PrintWriter(outputStream);
+			outputWriter.println(INPUT_TEXT);
+			outputWriter.flush();
+		} // 'close' throws IOException
+	}
+
+	// Output data ...
+
+	public static final Map<String, String> OUTPUT_TEXT_MAP;
+
+	static {
+		Map<String, String> outputMap = new HashMap<String, String>();
+		
+		outputMap.put(".ext0", "The slow brown fox jumps over the happy dog.");
+		outputMap.put(".ext3", INPUT_TEXT);
+
+		outputMap.put(".ext1", "The lethargic brown fox jumps over the energetic dog.");
+		outputMap.put(".ext4", "The quick brown fox walks over the lazy meadow.");
+
+		outputMap.put(".ext2", "The quick brown elephant jumps beside the lazy dog.");
+		outputMap.put(".ext5", "The quick brown fox strolls behind the lazy dog.");
+
+		outputMap.put(".ext6", INPUT_TEXT);
+		outputMap.put(".ext7", INPUT_TEXT);
+		
+		OUTPUT_TEXT_MAP = outputMap;
+	}
+
+	protected String readOutputFile(String outputPath) throws IOException {
+		try ( InputStream inputStream = new FileInputStream(outputPath) ) { // throws FileNotFoundException
+			BufferedReader inputReader = new BufferedReader( new InputStreamReader(inputStream) );
+			String outputLine = inputReader.readLine(); // throws IOException
+			return outputLine;
+		} // 'close' throws IOException			
+	}
+
+	protected List<String> verifyOutputFiles(String outputDir) throws IOException {
+		List<String> errors = new ArrayList<String>();
+		
+		for ( int fileNo = 0; fileNo < NUM_FILES; fileNo++ ) {
+			for ( int extNo = 0; extNo < NUM_EXTS; extNo++ ) {
+				String outputName = getInputName(fileNo, extNo);
+				String outputPath = outputDir + '/' + outputName;
+				String outputLine = readOutputFile(outputPath); // throws IOException
+				
+				String outputExt = getExtension(extNo);
+				
+				String expectedOutput = OUTPUT_TEXT_MAP.get(outputExt);
+				
+				if ( !outputLine.equals(expectedOutput) ) {
+					String error = "Incorrect content [ " + outputName + " ]; expected [ " + expectedOutput + " ] got [ " + outputLine + " ]";
+					errors.add(error);
+				}
+			}
+		}
+		
+		return errors;
+	}
+
+	protected void verifyOutput(String outputDir) throws IOException, AssertionFailedError {
+		List<String> outputErrors = verifyOutputFiles(outputDir); // throws IOException
+		processErrors("expected output", outputErrors); // throws AssertionFailedError
+	}
+
+	//
+
+	@Test
+	void testMultiText() throws Exception {
+		String dataDir = getDataDir();
+
+		String propertiesDir = dataDir + '/' + "properties";
+		
+		String inputDir = dataDir + '/' + "input";
+		String outputDir = dataDir + '/' + "output";
+		
+		(new File(propertiesDir)).mkdir();
+		writeRulesData(propertiesDir);
+
+		(new File(inputDir)).mkdir();
+		writeInputData(inputDir);
+
+		String[] args = new String[] {
+			"-tf", propertiesDir + '/' + TIER0_MASTER_PROPERTIES,
+			"-tf", propertiesDir + '/' + TIER1_MASTER_PROPERTIES,
+			"-tf", propertiesDir + '/' + TIER2_MASTER_PROPERTIES
+		};
+
+		byte[] logBytes = runTransformer(
+			inputDir, outputDir,
+			args,
+			DO_DEBUG_LOGGING,
+			getLogFragments() );
+		
+		verifyOutput(outputDir); // throws IOException, 
+	}
+}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
@@ -99,6 +99,10 @@ public abstract class ActionImpl implements Action {
 		getLogger().debug(message, parms);
 	}
 
+	public boolean isDebugEnabled() {
+		return getLogger().isDebugEnabled();
+	}
+
 	public void info(String message, Object... parms) {
 		getLogger().info(message, parms);
 	}
@@ -515,8 +519,18 @@ public abstract class ActionImpl implements Action {
 		debug("[ {}.{} ]: Requested [ {} ] [ {} ]", className, methodName, inputName, inputCount);
 		ByteData inputData = read(inputName, inputStream, inputCount); // throws
 																		// JakartaTransformException
-		debug("[ {}.{} ]: Obtained [ {} ] [ {} ] [ {} ]", className, methodName, inputName, inputData.length,
-			inputData.data);
+
+		if (isDebugEnabled()) {
+			byte[] altInputData;
+			if (inputData.length < inputData.data.length) {
+				altInputData = new byte[inputData.length];
+				System.arraycopy(inputData.data, 0, altInputData, 0, inputData.length);
+			} else {
+				altInputData = inputData.data;
+			}
+			debug("[ {}.{} ]: Obtained [ {} ] [ {} ] [ {} ]", className, methodName, inputName, inputData.length,
+				altInputData);
+		}
 
 		ByteData outputData;
 		try {
@@ -531,8 +545,17 @@ public abstract class ActionImpl implements Action {
 			debug("[ {}.{} ]: Null transform", className, methodName);
 			outputData = inputData;
 		} else {
-			debug("[ {}.{} ]: Active transform [ {} ] [ {} ] [ {} ]", className, methodName, outputData.name,
-				outputData.length, outputData.data);
+			if (isDebugEnabled()) {
+				byte[] altOutputData;
+				if (outputData.length < outputData.data.length) {
+					altOutputData = new byte[outputData.length];
+					System.arraycopy(outputData.data, 0, altOutputData, 0, outputData.length);
+				} else {
+					altOutputData = outputData.data;
+				}
+				debug("[ {}.{} ]: Active transform [ {} ] [ {} ] [ {} ]", className, methodName, outputData.name,
+					outputData.length, altOutputData);
+			}
 		}
 
 		return new InputStreamData(outputData);


### PR DESCRIPTION
Enable rules options to be specified multiple times.

Tested via:

transformer.test.TestTransformerMultiText.testMultiText()
-- Setup three tiers of overlapping master text files.  Verify that the overlapping updates are made with last specified taking precedence.  Verify log output when master property file assignments are overlaid.

transformer.test.TestTransformerMultiRenames.testMultiRenames()
-- Setup three tiers of overlapping package rename and package version rules files.  Verify that the overlapping updates are made with last specified taking precedence.  Verify log output when package rename and package version update values are overlaid.
