### PR TITLE
ci: Update workflow to use released JDK 15

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -21,7 +21,7 @@ jobs:
   JDKxx_Matrix:
     strategy:
       matrix:
-        java: [ 11, 14, 15-ea ]
+        java: [ 11, 15 ]
         os: [ ubuntu-latest ]
         include:
         - os: ubuntu-latest

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/data/Sample_SecurityAPI_Javax.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/data/Sample_SecurityAPI_Javax.java
@@ -11,8 +11,6 @@
 
 package transformer.test.data;
 
-import javax.security.auth.message.config.AuthConfigFactory;
-
 public class Sample_SecurityAPI_Javax {
 
 	public javax.security.auth.message.config.AuthConfigFactory getSampleValue() {

--- a/org.eclipse.transformer/src/test/java/org/eclipse/transformer/action/impl/ClassActionTest.java
+++ b/org.eclipse.transformer/src/test/java/org/eclipse/transformer/action/impl/ClassActionTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.eclipse.transformer.action.Action;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -129,7 +130,10 @@ public class ClassActionTest {
 
 		assertThat(attribute).as("transformed class module name, flags, and version")
 			.get()
-			.isEqualToComparingOnlyGivenFields(originalModule, "module_name", "module_flags", "module_version");
+			.usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
+				.withIgnoredFields("requires", "exports", "opens", "uses", "provides")
+				.build())
+			.isEqualTo(originalModule);
 
 		assertThat(attribute).map(m -> m.requires)
 			.get(InstanceOfAssertFactories.array(ModuleAttribute.Require[].class))
@@ -262,7 +266,8 @@ public class ClassActionTest {
 
 		assertThat(attribute(EnclosingMethodAttribute.class, transformed)).as("transformed class enclosing method")
 			.get()
-			.isEqualToComparingFieldByField(new EnclosingMethodAttribute("transformed/enclosing/Enclosing", "method",
+			.usingRecursiveComparison()
+			.isEqualTo(new EnclosingMethodAttribute("transformed/enclosing/Enclosing", "method",
 				"(Ltransformed/param/Param1;Lpkg/other/Param2;)Ltransformed/result/Result;"));
 
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -399,12 +399,12 @@
 				<version>4.0.1</version>
 				<scope>test</scope>
 			</dependency>
-                        <dependency>
+			<dependency>
 				<groupId>javax.security.auth.message</groupId>
 				<artifactId>javax.security.auth.message-api</artifactId>
 				<version>1.1.1</version>
-                                <scope>test</scope>
-                        </dependency>
+				<scope>test</scope>
+			</dependency>
 			<dependency>
 				<groupId>jakarta.annotation</groupId>
 				<artifactId>jakarta.annotation-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
 					</executions>
 					<configuration>
 						<detectJavaApiLink>false</detectJavaApiLink>
+						<doclint>none</doclint>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 		<revision>0.2.0-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>8</java.version>
+		<java.release>8</java.release>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<bnd.version>5.1.2</bnd.version>
@@ -118,11 +119,11 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.1</version>
 					<configuration>
-						<source>${maven.compiler.source}</source>
-						<target>${maven.compiler.target}</target>
 						<showWarnings>true</showWarnings>
 						<showDeprecation>true</showDeprecation>
-						<compilerArgument>-Xlint:unchecked</compilerArgument>
+						<compilerArgs>
+							<arg>-Xlint:unchecked</arg>
+						</compilerArgs>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -511,6 +512,15 @@
 	</dependencyManagement>
 
 	<profiles>
+		<profile>
+			<id>java-release</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>${java.release}</maven.compiler.release>
+			</properties>
+		</profile>
 		<profile>
 			<id>ossrh</id>
 			<properties>


### PR DESCRIPTION
We now remove JDK 14 as it is EOL.
