### PR TITLE
github actions: Configure to not build the dependabot branches

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -2,6 +2,8 @@ name: CI Build
 
 on:
   push:
+    branches-ignore:
+    - 'dependabot/**'
     paths-ignore:
     - 'docs/**'
     - '.github/**/*docs*'


### PR DESCRIPTION
We just want to build the PRs made by dependabot.
