### PR TITLE
fixes #183 - add `attach` parameter to maven plugin to allow disabling addition to attached artifacts

### DIFF
--- a/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
+++ b/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
@@ -70,6 +70,9 @@ public class TransformMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.build.directory}", required = true)
 	private File				outputDirectory;
 
+	@Parameter(defaultValue = "true", property = "transformer-plugin.attach", required = true)
+	private Boolean				attach;
+
 	@Component
 	private MavenProjectHelper	projectHelper;
 
@@ -124,7 +127,9 @@ public class TransformMojo extends AbstractMojo {
 			throw new MojoFailureException("Transformer failed with an error: " + Transformer.RC_DESCRIPTIONS[rc]);
 		}
 
-		projectHelper.attachArtifact(project, sourceArtifact.getType(), targetClassifier, targetFile);
+		if (attach) {
+			projectHelper.attachArtifact(project, sourceArtifact.getType(), targetClassifier, targetFile);
+		}
 	}
 
 	/**
@@ -205,4 +210,9 @@ public class TransformMojo extends AbstractMojo {
 	void setOutputDirectory(File outputDirectory) {
 		this.outputDirectory = outputDirectory;
 	}
+
+	void setAttach(Boolean attach) {
+		this.attach = attach;
+	}
+
 }

--- a/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
+++ b/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
@@ -152,6 +152,44 @@ public class TransformMojoTest {
 		assertTrue(classifiers.contains("test3-transformed"));
 	}
 
+	@Test
+	public void testProjectArtifactTransformerPluginNoAttach() throws Exception {
+		final TransformMojo mojo = new TransformMojo();
+		mojo.setProjectHelper(this.rule.lookup(MavenProjectHelper.class));
+		mojo.setOverwrite(true);
+		mojo.setOutputDirectory(new File("target"));
+		mojo.setAttach(false);
+
+		assertNotNull(mojo);
+
+		final File targetDirectory = this.resources.getBasedir("transform-build-artifact");
+		final File modelDirectory = new File(targetDirectory, "target/model");
+		final File pom = new File(targetDirectory, "pom.xml");
+
+		final MavenProject mavenProject = createMavenProject(modelDirectory, pom, "war", "rest-sample");
+		mavenProject.getArtifact()
+			.setFile(createService());
+
+		mojo.setProject(mavenProject);
+		mojo.setClassifier("transformed");
+
+		final Artifact[] sourceArtifacts = mojo.getSourceArtifacts();
+		assertEquals(1, sourceArtifacts.length);
+		assertEquals("org.superbiz.rest", sourceArtifacts[0].getGroupId());
+		assertEquals("rest-sample", sourceArtifacts[0].getArtifactId());
+		assertEquals("1.0-SNAPSHOT", sourceArtifacts[0].getVersion());
+		assertEquals("war", sourceArtifacts[0].getType());
+		assertNull(sourceArtifacts[0].getClassifier());
+
+		final Transformer transformer = mojo.getTransformer();
+		assertNotNull(transformer);
+
+		mojo.transform(transformer, sourceArtifacts[0]);
+
+		assertEquals(0, mavenProject.getAttachedArtifacts()
+			.size());
+	}
+
 	public MavenProject createMavenProject(final File modelDirectory, final File pom, final String packaging,
 		final String artfifactId) {
 		final MavenProject mavenProject = new MavenProject();


### PR DESCRIPTION
fixes #183 - add `attach` parameter to maven plugin to allow disabling addition to attached artifacts

Tests have been added and tested locally, but there is possibly an issue with `junit` version, as currently maven tests seem not to be executed due to `junit` versions mismatch (see #71)