### PR TITLE
Allow maven plugin to be used in a different artifact to the source

### DIFF
--- a/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/SourceArtifact.java
+++ b/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/SourceArtifact.java
@@ -1,0 +1,126 @@
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
+ ********************************************************************************/
+
+package org.eclipse.transformer.maven;
+
+/**
+ * @author tevans
+ *
+ */
+public class SourceArtifact {
+
+	private String	groupId;
+	private String	artifactId;
+	private String	version;
+	private String	classifier;
+	private String	type;
+	private String	scope;
+
+	/**
+	 * @return the groupId
+	 */
+	public String getGroupId() {
+		return groupId;
+	}
+
+	/**
+	 * @return the artifactId
+	 */
+	public String getArtifactId() {
+		return artifactId;
+	}
+
+	/**
+	 * @return the version
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * @return the classifier
+	 */
+	public String getClassifier() {
+		return classifier;
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @return the scope
+	 */
+	public String getScope() {
+		return scope;
+	}
+
+	public boolean isValid() {
+		return this.groupId != null && this.groupId.length() > 0 && this.artifactId != null
+			&& this.artifactId.length() > 0 && this.version != null && this.version.length() > 0;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return groupId + ":" + artifactId + ":" + version
+			+ ":" + classifier + ":" + type + ":" + scope;
+	}
+
+	/**
+	 * @param groupId the groupId to set
+	 */
+	public void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	/**
+	 * @param artifactId the artifactId to set
+	 */
+	public void setArtifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+
+	/**
+	 * @param version the version to set
+	 */
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	/**
+	 * @param classifier the classifier to set
+	 */
+	public void setClassifier(String classifier) {
+		this.classifier = classifier;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	/**
+	 * @param scope the scope to set
+	 */
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+}


### PR DESCRIPTION
fixes #139 
Signed-off-by: tevans <tevans@uk.ibm.com>

I'm not quite sure that I have the config right here. I also haven't found time to update the unit tests.
Hence why I am going to leave this as a draft PR for now. It will be a couple of weeks until I can come back to this.

The original pattern where an artifact in the same project is transformed will still work with what I have here except that the classifier is now optional. If not specified and the resulting ID clashes with the original then an exception is thrown.
e.g.
artifactA-1.0.jar -> artifactA-1.0.jar
or
artifactA1.0.jar -> artifactA-1.0-transformed.jar

The new configuration I have added means that the source artifacts can be taken from the project's dependencies. Instead of attaching the new artifacts to the project, they are set into it. i.e. is is assumed that there is nothing else in the target project.

Here is an example pom.xml where artifactA depends on artifactB. artifactB is transformed to become artifactA.
```
<project>
  <groupId>mygroup</groupId>
  <artifactId>artifactA</artifactId>
  <version>1.0</version>

  <dependencies>
    <dependency>
      <groupId>mygroup</groupId>
      <artifactId>artifactB</artifactId>
      <version>1.0</version>
      <scope>provided</scope> <!-- not transitive -->
    </dependency>
  </dependencies>

  <build>
    <plugins>
      <plugin>
        <groupId>org.eclipse.transformer</groupId>
        <artifactId>org.eclipse.transformer.maven</artifactId>
        <version>0.3.0-SNAPSHOT</version>
        <configuration>
          <attach>false</attach> <!-- I don't like the need for this -->
          <sourceArtifacts>
            <sourceArtifact>
              <groupId>mygroup</groupId>
              <artifactId>artifactB</artifactId>
              <version>1.0</version>
            </sourceArtifact>
          </sourceArtifacts>
        </configuration>
        <executions>
          <execution>
            <goals>
              <goal>run</goal>
            </goals>
            <phase>package</phase>
          </execution>
        </executions>
      </plugin>
    </plugins>
  </build>
</project>
```