### PR TITLE
Rename properties file action

### DIFF
--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
@@ -48,7 +48,7 @@ public class PropertiesActionImpl extends ActionImpl {
 
 	@Override
 	public String getName() {
-		return "Properties file relocate";
+		return "Properties File Action";
 	}
 
 	@Override


### PR DESCRIPTION
Changed the properties action name from "Properties file relocate" to "Properties File Action".