### PR TITLE
ci: Disable fail-fast until we can get the private key removal fixed

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -39,6 +39,7 @@ defaults:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
         java: [ '11', '16' ]


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=563870#c46

