### PR TITLE
ci: Use fork of actions/setup-java with subkey fix

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v2
     - name: Set up Java ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: bjhargrave/setup-java@only-subkey-signing # actions/setup-java@v2
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
This is temporary while we wait for GitHub to merge
https://github.com/actions/setup-java/pull/226

