### PR TITLE
maven: add `attach` parameter

### DIFF
--- a/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
+++ b/org.eclipse.transformer.maven/src/main/java/org/eclipse/transformer/maven/TransformMojo.java
@@ -56,6 +56,9 @@ public class TransformMojo extends AbstractMojo {
 	@Parameter(defaultValue = "true", property = "transformer-plugin.overwrite", required = true)
 	private boolean				overwrite;
 
+	@Parameter(defaultValue = "true", property = "transformer-plugin.attach", required = true)
+	private boolean				attach;
+
 	@Parameter(property = "transformer-plugin.renames", defaultValue = "")
 	private String				rulesRenamesUri;
 
@@ -193,7 +196,9 @@ public class TransformMojo extends AbstractMojo {
 			throw new MojoFailureException("Transformer failed with an error: " + rc);
 		}
 
-		projectHelper.attachArtifact(project, sourceArtifact.getType(), targetClassifier, targetFile);
+		if (attach) {
+			projectHelper.attachArtifact(project, sourceArtifact.getType(), targetClassifier, targetFile);
+		}
 	}
 
 	/**
@@ -237,11 +242,16 @@ public class TransformMojo extends AbstractMojo {
 		this.projectHelper = projectHelper;
 	}
 
-	void setOverwrite(Boolean overwrite) {
+	void setOverwrite(boolean overwrite) {
 		this.overwrite = overwrite;
 	}
 
 	void setOutputDirectory(File outputDirectory) {
 		this.outputDirectory = outputDirectory;
 	}
+
+	void setAttach(boolean attach) {
+		this.attach = attach;
+	}
+
 }

--- a/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
+++ b/org.eclipse.transformer.maven/src/test/java/org/eclipse/transformer/maven/TransformMojoTest.java
@@ -48,6 +48,7 @@ public class TransformMojoTest {
 		mojo.setProjectHelper(this.rule.lookup(MavenProjectHelper.class));
 		mojo.setOverwrite(true);
 		mojo.setOutputDirectory(new File("target"));
+		mojo.setAttach(true);
 
 		assertNotNull(mojo);
 
@@ -89,6 +90,7 @@ public class TransformMojoTest {
 		final TransformMojo mojo = new TransformMojo();
 		mojo.setOverwrite(true);
 		mojo.setProjectHelper(this.rule.lookup(MavenProjectHelper.class));
+		mojo.setAttach(true);
 
 		assertNotNull(mojo);
 
@@ -143,6 +145,41 @@ public class TransformMojoTest {
 		assertTrue(classifiers.contains("test1-transformed"));
 		assertTrue(classifiers.contains("test2-transformed"));
 		assertTrue(classifiers.contains("test3-transformed"));
+	}
+
+	@Test
+	public void testProjectArtifactTransformerPluginNoAttach() throws Exception {
+		final TransformMojo mojo = new TransformMojo();
+		mojo.setProjectHelper(this.rule.lookup(MavenProjectHelper.class));
+		mojo.setOverwrite(true);
+		mojo.setOutputDirectory(new File("target"));
+		mojo.setAttach(false);
+
+		assertNotNull(mojo);
+
+		final File targetDirectory = this.resources.getBasedir("transform-build-artifact");
+		final File modelDirectory = new File(targetDirectory, "target/model");
+		final File pom = new File(targetDirectory, "pom.xml");
+
+		final MavenProject mavenProject = createMavenProject(modelDirectory, pom, "war", "rest-sample");
+		mavenProject.getArtifact()
+			.setFile(createService());
+
+		mojo.setProject(mavenProject);
+		mojo.setClassifier("transformed");
+
+		final Artifact[] sourceArtifacts = mojo.getSourceArtifacts();
+		assertEquals(1, sourceArtifacts.length);
+		assertEquals("org.superbiz.rest", sourceArtifacts[0].getGroupId());
+		assertEquals("rest-sample", sourceArtifacts[0].getArtifactId());
+		assertEquals("1.0-SNAPSHOT", sourceArtifacts[0].getVersion());
+		assertEquals("war", sourceArtifacts[0].getType());
+		assertNull(sourceArtifacts[0].getClassifier());
+
+		mojo.transform(sourceArtifacts[0]);
+
+		assertEquals(0, mavenProject.getAttachedArtifacts()
+			.size());
 	}
 
 	public MavenProject createMavenProject(final File modelDirectory, final File pom, final String packaging,


### PR DESCRIPTION
Add `attach` parameter to maven plugin to allow disabling addition to
attached artifacts.

Fixes https://github.com/eclipse/transformer/issues/137

Closes #138 (replaces that PR).