### PR TITLE
Avoid leaking verbose/quiet abstraction into lib code

### DIFF
--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/DualLogger.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/DualLogger.java
@@ -82,7 +82,7 @@ class DualLogger extends SubstituteLogger {
 	public void debug(Marker marker, String format, Object... arguments) {
 		if (isDebugEnabled(marker)) {
 			if (isConsoleMarker(marker)) {
-				FormattingTuple tp = MessageFormatter.format(format, arguments);
+				FormattingTuple tp = MessageFormatter.arrayFormat(format, arguments);
 				systemOut.accept(tp.getMessage(), tp.getThrowable());
 				super.debug(marker, tp.getMessage(), tp.getThrowable());
 			} else {
@@ -134,7 +134,7 @@ class DualLogger extends SubstituteLogger {
 	@Override
 	public void info(Marker marker, String format, Object... arguments) {
 		if (isConsoleMarker(marker)) {
-			FormattingTuple tp = MessageFormatter.format(format, arguments);
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, arguments);
 			systemOut.accept(tp.getMessage(), tp.getThrowable());
 			super.info(marker, tp.getMessage(), tp.getThrowable());
 			return;
@@ -183,7 +183,7 @@ class DualLogger extends SubstituteLogger {
 	@Override
 	public void error(Marker marker, String format, Object... arguments) {
 		if (isConsoleMarker(marker)) {
-			FormattingTuple tp = MessageFormatter.format(format, arguments);
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, arguments);
 			systemErr.accept(tp.getMessage(), tp.getThrowable());
 			super.error(marker, tp.getMessage(), tp.getThrowable());
 			return;
@@ -239,7 +239,7 @@ class DualLogger extends SubstituteLogger {
 	public void trace(Marker marker, String format, Object... arguments) {
 		if (isTraceEnabled(marker)) {
 			if (isConsoleMarker(marker)) {
-				FormattingTuple tp = MessageFormatter.format(format, arguments);
+				FormattingTuple tp = MessageFormatter.arrayFormat(format, arguments);
 				systemOut.accept(tp.getMessage(), tp.getThrowable());
 				super.trace(marker, tp.getMessage(), tp.getThrowable());
 			} else {
@@ -291,7 +291,7 @@ class DualLogger extends SubstituteLogger {
 	@Override
 	public void warn(Marker marker, String format, Object... arguments) {
 		if (isConsoleMarker(marker)) {
-			FormattingTuple tp = MessageFormatter.format(format, arguments);
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, arguments);
 			systemErr.accept(tp.getMessage(), tp.getThrowable());
 			super.warn(marker, tp.getMessage(), tp.getThrowable());
 			return;

--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/LoggerProperty.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/LoggerProperty.java
@@ -16,7 +16,7 @@ public enum LoggerProperty {
 	LOG_CACHE_OUTPUT("org.slf4j.simpleLogger.cacheOutputStream"),
 
 	LOG_LEVEL_ROOT("org.slf4j.simpleLogger.defaultLogLevel"),
-	LOG_LEVEL_CHILD("org.slf4j.simpleLogger.log.a.b.c"),
+	LOG_LEVEL_PREFIX("org.slf4j.simpleLogger.log."),
 	LOG_LEVEL_IN_BRACkETS("org.slf4j.simpleLogger.levelInBrackets"),
 
 	LOG_SHOW_DATE_TIME("org.slf4j.simpleLogger.showDateTime"),
@@ -32,7 +32,8 @@ public enum LoggerProperty {
 
 	private final String propertyName;
 
-	public String getPropertyName() {
+	@Override
+	public String toString() {
 		return propertyName;
 	}
 }

--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/LoggerSettings.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/LoggerSettings.java
@@ -17,7 +17,7 @@ import org.eclipse.transformer.AppOption;
 import org.eclipse.transformer.TransformOptions;
 
 public class LoggerSettings {
-	public final boolean	isTerse;
+	public final boolean	isQuiet;
 	public final boolean	isVerbose;
 
 	public final List<String>	properties;
@@ -28,7 +28,7 @@ public class LoggerSettings {
 	public final String		logFileName;
 
 	public LoggerSettings(TransformOptions options) {
-		this.isTerse = options.hasOption(AppOption.LOG_TERSE);
+		this.isQuiet = options.hasOption(AppOption.LOG_QUIET);
 		this.isVerbose = options.hasOption(AppOption.LOG_VERBOSE);
 
 		this.properties = options.getOptionValues(AppOption.LOG_PROPERTY);
@@ -38,20 +38,5 @@ public class LoggerSettings {
 
 		this.logLevel = options.getOptionValue(AppOption.LOG_LEVEL);
 		this.logFileName = options.normalize(options.getOptionValue(AppOption.LOG_FILE));
-
-		// System.out.println("LoggerSettings: isTerse [ " + this.isTerse +
-		// " ]");
-		// System.out.println("LoggerSettings: isVerbose [ " +
-		// this.isVerbose + " ]");
-		// System.out.println("LoggerSettings: properties [ " +
-		// this.properties + " ]");
-		// System.out.println("LoggerSettings: propertyFileName [ " +
-		// this.propertyFileName + " ]");
-		// System.out.println("LoggerSettings: logName [ " + this.logName +
-		// " ]");
-		// System.out.println("LoggerSettings: logLevel [ " + this.logLevel
-		// + " ]");
-		// System.out.println("LoggerSettings: logFileName [ " +
-		// this.logFileName + " ]");
 	}
 }

--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerCLI.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerCLI.java
@@ -359,7 +359,7 @@ public class TransformerCLI implements TransformOptions {
 			helpWriter.println("Logging Properties:");
 			for (LoggerProperty loggerProperty : LoggerProperty
 				.values()) {
-				helpWriter.println("  [ " + loggerProperty.getPropertyName() + " ]");
+				helpWriter.println("  [ " + loggerProperty + " ]");
 			}
 
 			helpWriter.flush();

--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerCLI.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerCLI.java
@@ -214,29 +214,14 @@ public class TransformerCLI implements TransformOptions {
 
 	private final PrintStream sysOut;
 
-	protected PrintStream getSystemOut() {
+	public PrintStream getSystemOut() {
 		return sysOut;
 	}
 
 	private final PrintStream sysErr;
 
-	protected PrintStream getSystemErr() {
+	public PrintStream getSystemErr() {
 		return sysErr;
-	}
-
-	public void systemPrint(PrintStream output, String message, Object... parms) {
-		if (parms.length != 0) {
-			message = String.format(message, parms);
-		}
-		output.println(message);
-	}
-
-	public void errorPrint(String message, Object... parms) {
-		systemPrint(getSystemErr(), message, parms);
-	}
-
-	public void outputPrint(String message, Object... parms) {
-		systemPrint(getSystemOut(), message, parms);
 	}
 
 	//

--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerLoggerFactory.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerLoggerFactory.java
@@ -21,6 +21,8 @@ import org.eclipse.transformer.Transformer;
 import org.eclipse.transformer.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
 
 import aQute.lib.io.IO;
 import aQute.lib.utf8properties.UTF8Properties;
@@ -102,31 +104,17 @@ public class TransformerLoggerFactory {
 		return settings;
 	}
 
-	protected void verboseOutput(String message, Object... parms) {
+	private void verboseOutput(String format, Object... args) {
 		if (settings.isVerbose) {
-			cli.outputPrint(message, parms);
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, args);
+			consolePrint(cli.getSystemOut()).accept(tp.getMessage(), tp.getThrowable());
 		}
 	}
 
-	protected void normalOutput(String message, Object... parms) {
-		if (!settings.isVerbose && !settings.isTerse) {
-			cli.outputPrint(message, parms);
-		}
-	}
-
-	protected void nonTerseOutput(String message, Object... parms) {
-		// System.out.println("nonTerseOutput [ " + (settings.isTerse ?
-		// "Blocked" : "Unblocked") + " ] [ " + message + " ] [ " + parms + "
-		// ]");
-
+	private void nonTerseOutput(String format, Object... args) {
 		if (!settings.isTerse) {
-			cli.outputPrint(message, parms);
-		}
-	}
-
-	protected void terseOutput(String message, Object... parms) {
-		if (settings.isTerse) {
-			cli.outputPrint(message, parms);
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, args);
+			consolePrint(cli.getSystemOut()).accept(tp.getMessage(), tp.getThrowable());
 		}
 	}
 
@@ -163,7 +151,7 @@ public class TransformerLoggerFactory {
 		if (toSysErr) {
 			logFile = "System.err";
 		}
-		verboseOutput("Logging to [ %s ]", logFile);
+		verboseOutput("Logging to [ {} ]", logFile);
 
 		String logName = selectLoggerName();
 		Logger logger = LoggerFactory.getLogger(logName);
@@ -249,7 +237,7 @@ public class TransformerLoggerFactory {
 			logNameCase = "Assigned";
 			logName = settings.logName;
 		}
-		verboseOutput("Logger name [ %s ] (%s)", logName, logNameCase);
+		verboseOutput("Logger name [ {} ] ({})", logName, logNameCase);
 
 		return logName;
 	}
@@ -295,8 +283,8 @@ public class TransformerLoggerFactory {
 
 		String completedPropertyName = completePropertyName(propertyName);
 		if (completedPropertyName != null) {
-			verboseOutput("Transformer logging property adjusted from [ %s ] to [ %s ]", propertyName,
-				completedPropertyName, propertyValue);
+			verboseOutput("Transformer logging property adjusted from [ {} ] to [ {} ]", propertyName,
+				completedPropertyName);
 		} else {
 			completedPropertyName = propertyName;
 		}
@@ -314,13 +302,13 @@ public class TransformerLoggerFactory {
 		// oldPropertyValue + " ]");
 
 		if (oldPropertyValue != null) {
-			nonTerseOutput("Blocked assignment of logging property [ %s ] to [ %s ] by prior value [ %s ]",
+			nonTerseOutput("Blocked assignment of logging property [ {} ] to [ {} ] by prior value [ {} ]",
 				propertyName, newPropertyValue, oldPropertyValue);
 
 		} else {
 			System.setProperty(propertyName, newPropertyValue);
 
-			nonTerseOutput("Assigning logging property [ %s ] to [ %s ]", propertyName, newPropertyValue);
+			nonTerseOutput("Assigning logging property [ {} ] to [ {} ]", propertyName, newPropertyValue);
 		}
 
 		// String assignedPropertyValue = System.getProperty(propertyName);

--- a/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerLoggerFactory.java
+++ b/org.eclipse.transformer.cli/src/main/java/org/eclipse/transformer/cli/TransformerLoggerFactory.java
@@ -111,41 +111,19 @@ public class TransformerLoggerFactory {
 		}
 	}
 
-	private void nonTerseOutput(String format, Object... args) {
-		if (!settings.isTerse) {
+	private void nonQuietOutput(String format, Object... args) {
+		if (!settings.isQuiet) {
 			FormattingTuple tp = MessageFormatter.arrayFormat(format, args);
 			consolePrint(cli.getSystemOut()).accept(tp.getMessage(), tp.getThrowable());
 		}
 	}
 
-	// Options from the transformer:
-	//
-	// LOG_TERSE("q", "quiet", "Display quiet output",
-	// !OptionSettings.HAS_ARG, !OptionSettings.HAS_ARGS,
-	// !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
-	// LOG_VERBOSE("v", "verbose", "Display verbose output",
-	// !OptionSettings.HAS_ARG, !OptionSettings.HAS_ARGS,
-	// !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
-	// LOG_PROPERTY("lp", "logProperty", "Logging property",
-	// !OptionSettings.HAS_ARG, OptionSettings.HAS_ARGS,
-	// !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
-	// LOG_PROPERTY_FILE("lpf", "logPropertyFile", "Logging properties file",
-	// OptionSettings.HAS_ARG, !OptionSettings.HAS_ARGS,
-	// !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
-	// LOG_LEVEL("ll", "logLevel", "Logging level",
-	// OptionSettings.HAS_ARG, !OptionSettings.HAS_ARGS,
-	// !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
-	// LOG_FILE("lf", "logFile", "Logging file",
-	// OptionSettings.HAS_ARG, !OptionSettings.HAS_ARGS,
-	// !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
-
-
-
 	//
 
 	public Logger createLogger() {
-		setLoggingProperties(); // throws TransformException
-		String logFile = System.getProperty(LoggerProperty.LOG_FILE.getPropertyName());
+		String loggerName = selectLoggerName();
+		setLoggingProperties(loggerName); // throws TransformException
+		String logFile = System.getProperty(LoggerProperty.LOG_FILE.toString());
 		boolean toSysOut = (logFile != null) && logFile.equals("System.out");
 		boolean toSysErr = (logFile == null) || logFile.equals("System.err");
 		if (toSysErr) {
@@ -153,8 +131,7 @@ public class TransformerLoggerFactory {
 		}
 		verboseOutput("Logging to [ {} ]", logFile);
 
-		String logName = selectLoggerName();
-		Logger logger = LoggerFactory.getLogger(logName);
+		Logger logger = LoggerFactory.getLogger(loggerName);
 		if (toSysOut || toSysErr) { // if logging to console
 			return logger;
 		}
@@ -169,26 +146,23 @@ public class TransformerLoggerFactory {
 			}
 		};
 	}
-	protected void setLoggingProperties() {
-		String logFilePropertyName = LoggerProperty.LOG_FILE.getPropertyName();
+
+	private void setLoggingProperties(String loggerName) {
+		String logFilePropertyName = LoggerProperty.LOG_FILE.toString();
 		if (settings.logFileName != null) {
 			setLoggingProperty(logFilePropertyName, settings.logFileName);
 		}
-		// else {
-		// System.out.println("Using preset logging property [ " +
-		// logFilePropertyName + " ] [ " +
-		// System.getProperty(logFilePropertyName) + " ]");
-		// }
 
-		String logLevelPropertyName = LoggerProperty.LOG_LEVEL_ROOT.getPropertyName();
+		String logLevelPropertyName = LoggerProperty.LOG_LEVEL_ROOT.toString();
 		if (settings.logLevel != null) {
 			setLoggingProperty(logLevelPropertyName, settings.logLevel);
 		}
-		// else {
-		// System.out.println("Using preset logging property [ " +
-		// logLevelPropertyName + " ] [ "
-		// + System.getProperty(logLevelPropertyName) + " ]");
-		// }
+
+		if (settings.isVerbose) {
+			setLoggingProperty(LoggerProperty.LOG_LEVEL_PREFIX + loggerName, "debug");
+		} else if (settings.isQuiet) {
+			setLoggingProperty(LoggerProperty.LOG_LEVEL_PREFIX + loggerName, "error");
+		}
 
 		if (settings.properties != null) {
 			for (String propertyAssignment : settings.properties) {
@@ -216,14 +190,6 @@ public class TransformerLoggerFactory {
 				setLoggingProperty(propertyName, propertyValue); // throws
 																	// TransformException
 			}
-		}
-
-		if (settings.isTerse) {
-			// Don't report; in terse mode!
-		} else if (settings.isVerbose) {
-			verboseOutput("Verbose output requested");
-		} else {
-			// Don't report use of default logging mode
 		}
 	}
 
@@ -302,13 +268,13 @@ public class TransformerLoggerFactory {
 		// oldPropertyValue + " ]");
 
 		if (oldPropertyValue != null) {
-			nonTerseOutput("Blocked assignment of logging property [ {} ] to [ {} ] by prior value [ {} ]",
+			nonQuietOutput("Blocked assignment of logging property [ {} ] to [ {} ] by prior value [ {} ]",
 				propertyName, newPropertyValue, oldPropertyValue);
 
 		} else {
 			System.setProperty(propertyName, newPropertyValue);
 
-			nonTerseOutput("Assigning logging property [ {} ] to [ {} ]", propertyName, newPropertyValue);
+			nonQuietOutput("Assigning logging property [ {} ] to [ {} ]", propertyName, newPropertyValue);
 		}
 
 		// String assignedPropertyValue = System.getProperty(propertyName);

--- a/org.eclipse.transformer.cli/src/test/java/transformer/test/TestCommandLine.java
+++ b/org.eclipse.transformer.cli/src/test/java/transformer/test/TestCommandLine.java
@@ -86,11 +86,14 @@ class TestCommandLine {
 	void testSetLogLevel() throws Exception {
 		TransformerCLI cli = new TransformerCLI(System.out, System.err, new String[] {
 			"--logName", name,
-			"--logProperty", "org.slf4j.simpleLogger.log." + name + "=debug"
+			"--quiet"
 		});
 		Transformer transformer = new Transformer(cli.getLogger(), cli);
 		Logger logger = transformer.getLogger();
-		assertThat(logger.isDebugEnabled()).isTrue();
+		assertThat(logger.isDebugEnabled()).isFalse();
+		assertThat(logger.isInfoEnabled()).isFalse();
+		assertThat(logger.isWarnEnabled()).isFalse();
+		assertThat(logger.isErrorEnabled()).isTrue();
 	}
 
 	@Test
@@ -104,7 +107,7 @@ class TestCommandLine {
 		try (PrintStream out = new PrintStream(sysOut); PrintStream err = new PrintStream(sysErr)) {
 			TransformerCLI cli = new TransformerCLI(out, err, new String[] {
 				"--logName", name,
-				"--logProperty", "org.slf4j.simpleLogger.log." + name + "=debug",
+				"--verbose",
 				"--logFile", logFileName
 			});
 			Transformer transformer = new Transformer(cli.getLogger(), cli);

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
@@ -22,7 +22,7 @@ public enum AppOption {
 	// !OptionSettings.HAS_ARG, !OptionSettings.HAS_ARGS,
 	// !OptionSettings.IS_REQUIRED, OptionSettings.NO_GROUP),
 
-	LOG_TERSE(new Settings("q", "quiet", "Display quiet output", !Settings.HAS_ARG, !Settings.HAS_ARGS,
+	LOG_QUIET(new Settings("q", "quiet", "Display quiet output", !Settings.HAS_ARG, !Settings.HAS_ARGS,
 		!Settings.IS_REQUIRED, Settings.NO_GROUP)),
 	LOG_VERBOSE(new Settings("v", "verbose", "Display verbose output", !Settings.HAS_ARG, !Settings.HAS_ARGS,
 		!Settings.IS_REQUIRED, Settings.NO_GROUP)),

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -99,12 +99,7 @@ public class Transformer {
 	public Transformer(Logger logger, TransformOptions options) {
 		this.logger = requireNonNull(logger);
 		this.options = requireNonNull(options);
-		isTerse = options.hasOption(AppOption.LOG_TERSE);
-		isVerbose = options.hasOption(AppOption.LOG_VERBOSE);
 	}
-
-	public boolean							isVerbose;
-	public boolean							isTerse;
 
 	public Set<String>						includes;
 	public Set<String>						excludes;
@@ -169,9 +164,7 @@ public class Transformer {
 			getLogger().error(consoleMarker, "Transformation rules cannot be used");
 			return ResultCode.RULES_ERROR_RC;
 		}
-		if (isVerbose) {
-			logRules();
-		}
+		logRules();
 
 		setActions();
 
@@ -884,91 +877,94 @@ public class Transformer {
 	// }
 
 	public void logRules() {
-		getLogger().info("Includes:");
+		if (!getLogger().isDebugEnabled()) {
+			return;
+		}
+		getLogger().debug("Includes:");
 		if ((includes == null) || includes.isEmpty()) {
-			getLogger().info("  [ ** NONE ** ]");
+			getLogger().debug("  [ ** NONE ** ]");
 		} else {
 			for (String include : includes) {
-				getLogger().info("  [ {} ]", include);
+				getLogger().debug("  [ {} ]", include);
 			}
 		}
 
-		getLogger().info("Excludes:");
+		getLogger().debug("Excludes:");
 		if ((excludes == null) || excludes.isEmpty()) {
-			getLogger().info("  [ ** NONE ** ]");
+			getLogger().debug("  [ ** NONE ** ]");
 		} else {
 			for (String exclude : excludes) {
-				getLogger().info("  [ {} ]", exclude);
+				getLogger().debug("  [ {} ]", exclude);
 			}
 		}
 
 		if (invert) {
-			getLogger().info("Package Renames: [ ** INVERTED ** ]");
+			getLogger().debug("Package Renames: [ ** INVERTED ** ]");
 		} else {
-			getLogger().info("Package Renames:");
+			getLogger().debug("Package Renames:");
 		}
 
 		if ((packageRenames == null) || packageRenames.isEmpty()) {
-			getLogger().info("  [ ** NONE ** ]");
+			getLogger().debug("  [ ** NONE ** ]");
 		} else {
 			for (Map.Entry<String, String> renameEntry : packageRenames.entrySet()) {
-				getLogger().info("  [ {} ]: [ {} ]", renameEntry.getKey(), renameEntry.getValue());
+				getLogger().debug("  [ {} ]: [ {} ]", renameEntry.getKey(), renameEntry.getValue());
 			}
 		}
 
-		getLogger().info("Package Versions:");
+		getLogger().debug("Package Versions:");
 		if ((packageVersions == null) || packageVersions.isEmpty()) {
-			getLogger().info("  [ ** NONE ** ]");
+			getLogger().debug("  [ ** NONE ** ]");
 		} else {
 			for (Map.Entry<String, String> versionEntry : packageVersions.entrySet()) {
-				getLogger().info("  [ {} ]: [ {} ]", versionEntry.getKey(), versionEntry.getValue());
+				getLogger().debug("  [ {} ]: [ {} ]", versionEntry.getKey(), versionEntry.getValue());
 			}
 		}
 
-		getLogger().info("Bundle Updates:");
+		getLogger().debug("Bundle Updates:");
 		if ((bundleUpdates == null) || bundleUpdates.isEmpty()) {
-			getLogger().info("  [ ** NONE ** ]");
+			getLogger().debug("  [ ** NONE ** ]");
 		} else {
 			for (Map.Entry<String, BundleData> updateEntry : bundleUpdates.entrySet()) {
 				BundleData updateData = updateEntry.getValue();
 
-				getLogger().info("  [ {} ]: [ {} ]", updateEntry.getKey(), updateData.getSymbolicName());
+				getLogger().debug("  [ {} ]: [ {} ]", updateEntry.getKey(), updateData.getSymbolicName());
 
-				getLogger().info("    [ Version ]: [ {} ]", updateData.getVersion());
+				getLogger().debug("    [ Version ]: [ {} ]", updateData.getVersion());
 
 				if (updateData.getAddName()) {
-					getLogger().info("    [ Name ]: [ " + BundleData.ADDITIVE_CHAR + "{} ]", updateData.getName());
+					getLogger().debug("    [ Name ]: [ " + BundleData.ADDITIVE_CHAR + "{} ]", updateData.getName());
 				} else {
-					getLogger().info("    [ Name ]: [ {} ]", updateData.getName());
+					getLogger().debug("    [ Name ]: [ {} ]", updateData.getName());
 				}
 
 				if (updateData.getAddDescription()) {
-					getLogger().info(
+					getLogger().debug(
 						"    [ Description ]: [ " + BundleData.ADDITIVE_CHAR + "{} ]", updateData.getDescription());
 				} else {
-					getLogger().info("    [ Description ]: [ {} ]", updateData.getDescription());
+					getLogger().debug("    [ Description ]: [ {} ]", updateData.getDescription());
 				}
 			}
 		}
 
-		getLogger().info("Java string substitutions:");
+		getLogger().debug("Java string substitutions:");
 		if ((directStrings == null) || directStrings.isEmpty()) {
-			getLogger().info("  [ ** NONE ** ]");
+			getLogger().debug("  [ ** NONE ** ]");
 		} else {
 			for (Map.Entry<String, String> directEntry : directStrings.entrySet()) {
-				getLogger().info("  [ {} ]: [ {} ]", directEntry.getKey(), directEntry.getValue());
+				getLogger().debug("  [ {} ]: [ {} ]", directEntry.getKey(), directEntry.getValue());
 			}
 		}
 
-		getLogger().info("Text substitutions:");
+		getLogger().debug("Text substitutions:");
 		if ((masterTextUpdates == null) || masterTextUpdates.isEmpty()) {
-			getLogger().info("  [ ** NONE ** ]");
+			getLogger().debug("  [ ** NONE ** ]");
 		} else {
 			for (Map.Entry<String, Map<String, String>> masterTextEntry : masterTextUpdates.entrySet()) {
-				getLogger().info("  Pattern [ {} ]", masterTextEntry.getKey());
+				getLogger().debug("  Pattern [ {} ]", masterTextEntry.getKey());
 				for (Map.Entry<String, String> substitution : masterTextEntry.getValue()
 					.entrySet()) {
-					getLogger().info("    [ {} ]: [ {} ]", substitution.getKey(), substitution.getValue());
+					getLogger().debug("    [ {} ]: [ {} ]", substitution.getKey(), substitution.getValue());
 				}
 			}
 		}
@@ -1044,10 +1040,8 @@ public class Transformer {
 
 		if (putIntoDirectory) {
 			useOutputName = useOutputName + '/' + inputName;
-			if (isVerbose) {
-				getLogger().info(consoleMarker, "Output generated using input name and output directory [ {} ]",
-					useOutputName);
-			}
+			getLogger().debug(consoleMarker, "Output generated using input name and output directory [ {} ]",
+				useOutputName);
 
 			useOutputFile = new File(useOutputName);
 			useOutputPath = useOutputFile.getAbsolutePath();
@@ -1085,10 +1079,8 @@ public class Transformer {
 			}
 		} else {
 			if (allowOverwrite) {
-				if (isVerbose) {
-					getLogger().info(consoleMarker, "Overwritten specified, but output [ {} ] does not exist",
-						useOutputPath);
-				}
+				getLogger().debug(consoleMarker, "Overwritten specified, but output [ {} ] does not exist",
+					useOutputPath);
 			}
 		}
 
@@ -1110,9 +1102,8 @@ public class Transformer {
 
 	public CompositeActionImpl getRootAction() {
 		if (rootAction == null) {
-			CompositeActionImpl useRootAction = new CompositeActionImpl(getLogger(), isTerse,
-				isVerbose,
-				getBuffer(), getSelectionRule(), getSignatureRule());
+			CompositeActionImpl useRootAction = new CompositeActionImpl(getLogger(), getBuffer(), getSelectionRule(),
+				getSignatureRule());
 
 			DirectoryActionImpl directoryAction = useRootAction.addUsing(DirectoryActionImpl::new);
 
@@ -1260,16 +1251,8 @@ public class Transformer {
 
 		acceptedAction.apply(inputName, inputFile, outputFile);
 
-		if (isTerse) {
-			acceptedAction.getLastActiveChanges()
-				.displayTerse(getLogger(), inputPath, outputPath);
-		} else if (isVerbose) {
-			acceptedAction.getLastActiveChanges()
-				.displayVerbose(getLogger(), inputPath, outputPath);
-		} else {
-			acceptedAction.getLastActiveChanges()
-				.display(getLogger(), inputPath, outputPath);
-		}
+		acceptedAction.getLastActiveChanges()
+			.log(getLogger(), inputPath, outputPath);
 	}
 
 	public Changes getLastActiveChanges() {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Changes.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Changes.java
@@ -38,9 +38,5 @@ public interface Changes {
 
 	void clearChanges();
 
-	void displayVerbose(Logger logger, String inputPath, String outputPath);
-
-	void display(Logger logger, String inputPath, String outputPath);
-
-	void displayTerse(Logger logger, String inputPath, String outputPath);
+	void log(Logger logger, String inputPath, String outputPath);
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ChangesImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ChangesImpl.java
@@ -105,25 +105,15 @@ public class ChangesImpl implements Changes {
 	}
 
 	@Override
-	public void displayTerse(Logger logger, String inputPath, String outputPath) {
-		if (!inputPath.equals(outputPath)) {
+	public void log(Logger logger, String inputPath, String outputPath) {
+		if (logger.isDebugEnabled(consoleMarker)) {
+			logger.debug(consoleMarker, "Input  [ {} ] as [ {} ]", getInputResourceName(), inputPath);
+			logger.debug(consoleMarker, "Output [ {} ] as [ {} ]", getOutputResourceName(), outputPath);
+			logger.debug(consoleMarker, "Replacements  [ {} ]", getReplacements());
+		} else if (logger.isInfoEnabled(consoleMarker)) {
 			if (!inputPath.equals(outputPath)) {
 				logger.info(consoleMarker, "Input [ {} ] as [ {} ]: {}", inputPath, outputPath, getChangeTag());
-			} else {
-				logger.info(consoleMarker, "Input [ {} ]: {}", inputPath, getChangeTag());
 			}
 		}
-	}
-
-	@Override
-	public void display(Logger logger, String inputPath, String outputPath) {
-		displayTerse(logger, inputPath, outputPath);
-	}
-
-	@Override
-	public void displayVerbose(Logger logger, String inputPath, String outputPath) {
-		logger.info(consoleMarker, "Input  [ {} ] as [ {} ]", getInputResourceName(), inputPath);
-		logger.info(consoleMarker, "Output [ {} ] as [ {} ]", getOutputResourceName(), outputPath);
-		logger.info(consoleMarker, "Replacements  [ {} ]", getReplacements());
 	}
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassChangesImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassChangesImpl.java
@@ -163,21 +163,25 @@ public class ClassChangesImpl extends ChangesImpl {
 	//
 
 	@Override
-	public void displayVerbose(Logger logger, String inputPath, String outputPath) {
-		logger.info(consoleMarker, "Input name [ {} ] as [ {} ]", getInputResourceName(), inputPath);
+	public void log(Logger logger, String inputPath, String outputPath) {
+		if (logger.isDebugEnabled(consoleMarker)) {
+			logger.debug(consoleMarker, "Input name [ {} ] as [ {} ]", getInputResourceName(), inputPath);
 
-		logger.info(consoleMarker, "Output name [ {} ] as [ {} ]", getOutputResourceName(), outputPath);
+			logger.debug(consoleMarker, "Output name [ {} ] as [ {} ]", getOutputResourceName(), outputPath);
 
-		logger.info(consoleMarker, "Class name [ {} ] [ {} ]", getInputClassName(), getOutputClassName());
+			logger.debug(consoleMarker, "Class name [ {} ] [ {} ]", getInputClassName(), getOutputClassName());
 
-		String useInputSuperName = getInputSuperName();
-		if (useInputSuperName != null) {
-			logger.info(consoleMarker, "Super class name [ {} ] [ {} ]", useInputSuperName, getOutputSuperName());
+			String useInputSuperName = getInputSuperName();
+			if (useInputSuperName != null) {
+				logger.debug(consoleMarker, "Super class name [ {} ] [ {} ]", useInputSuperName, getOutputSuperName());
+			}
+
+			logger.debug(consoleMarker, "Modified interfaces [ {} ]", getModifiedInterfaces());
+			logger.debug(consoleMarker, "Modified fields     [ {} ]", getModifiedFields());
+			logger.debug(consoleMarker, "Modified methods    [ {} ]", getModifiedMethods());
+			logger.debug(consoleMarker, "Modified constants  [ {} ]", getModifiedConstants());
+		} else {
+			super.log(logger, inputPath, outputPath);
 		}
-
-		logger.info(consoleMarker, "Modified interfaces [ {} ]", getModifiedInterfaces());
-		logger.info(consoleMarker, "Modified fields     [ {} ]", getModifiedFields());
-		logger.info(consoleMarker, "Modified methods    [ {} ]", getModifiedMethods());
-		logger.info(consoleMarker, "Modified constants  [ {} ]", getModifiedConstants());
 	}
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/CompositeActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/CompositeActionImpl.java
@@ -29,10 +29,10 @@ public class CompositeActionImpl extends ActionImpl implements CompositeAction {
 		return action;
 	}
 
-	public CompositeActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public CompositeActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 
 		this.actions = new ArrayList<>();
 		this.acceptedAction = null;

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ContainerActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ContainerActionImpl.java
@@ -38,10 +38,10 @@ public abstract class ContainerActionImpl extends ActionImpl implements Containe
 		return action;
 	}
 
-	public ContainerActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public ContainerActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 
 		this.compositeAction = createUsing(CompositeActionImpl::new);
 	}
@@ -107,19 +107,20 @@ public abstract class ContainerActionImpl extends ActionImpl implements Containe
 	//
 
 	protected void recordUnaccepted(String resourceName) {
-		debug("Resource [ {} ]: Not accepted", resourceName);
+		getLogger().debug("Resource [ {} ]: Not accepted", resourceName);
 
 		getActiveChanges().record();
 	}
 
 	protected void recordUnselected(Action action, String resourceName) {
-		debug("Resource [ {} ] Action [ {} ]: Accepted but not selected", resourceName, action.getName());
+		getLogger().debug("Resource [ {} ] Action [ {} ]: Accepted but not selected", resourceName, action.getName());
 
 		getActiveChanges().record(action, !ContainerChanges.HAS_CHANGES);
 	}
 
 	protected void recordTransform(Action action, String resourceName) {
-		debug("Resource [ {} ] Action [ {} ]: Changes [ {} ]", resourceName, action.getName(), action.hadChanges());
+		getLogger().debug("Resource [ {} ] Action [ {} ]: Changes [ {} ]", resourceName, action.getName(),
+			action.hadChanges());
 
 		getActiveChanges().record(action);
 	}
@@ -186,7 +187,8 @@ public abstract class ContainerActionImpl extends ActionImpl implements Containe
 				inputName = inputEntry.getName();
 				long inputLength = inputEntry.getSize();
 
-				debug("[ {}.{} ] [ {} ] Size [ {} ]", getClass().getSimpleName(), "apply", inputName, inputLength);
+				getLogger().debug("[ {}.{} ] [ {} ] Size [ {} ]", getClass().getSimpleName(), "apply", inputName,
+					inputLength);
 
 				boolean selected = select(inputName);
 				Action acceptedAction = acceptAction(inputName);

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ContainerChangesImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ContainerChangesImpl.java
@@ -272,91 +272,85 @@ public class ContainerChangesImpl extends ChangesImpl implements ContainerChange
 		return String.format(DATA_LINE, parms);
 	}
 
-	protected void displayChanges(Logger logger) {
-		logger.info(consoleMarker,
+	private void displayChanges(Logger logger) {
+		logger.debug(consoleMarker,
 			formatData("All Resources", getAllResources(), "Unselected", getAllUnselected(), "Selected",
 			getAllSelected(), ""));
 
-		logger.info(consoleMarker, SMALL_DASH_LINE);
-		logger.info(consoleMarker,
+		logger.debug(consoleMarker, SMALL_DASH_LINE);
+		logger.debug(consoleMarker,
 			formatData("All Actions", getAllSelected(), "Unchanged", getAllUnchanged(), "Changed",
 			getAllChanged(), ""));
 
 		for (String actionName : getActionNames()) {
 			int useUnchangedByAction = getUnchanged(actionName);
 			int useChangedByAction = getChanged(actionName);
-			logger.info(consoleMarker, formatData(actionName, useUnchangedByAction + useChangedByAction, "Unchanged",
+			logger.debug(consoleMarker, formatData(actionName, useUnchangedByAction + useChangedByAction, "Unchanged",
 				useUnchangedByAction, "Changed", useChangedByAction, ""));
 		}
 	}
 
 	@Override
-	public void displayVerbose(Logger logger, String inputPath, String outputPath) {
-		// ================================================================================
-		// [ Input ] [ test.jar ]
-		// [
-		// c:\dev\jakarta-repo-pub\jakartaee-prototype\dev\transformer\app\test.jar
-		// ]
-		// [ Output ] [ output_test.jar ]
-		// [
-		// c:\dev\jakarta-repo-pub\jakartaee-prototype\dev\transformer\app\testOutput.jar
-		// ]
-		// ================================================================================
-		// [ All Resources ] [ 55 ] Unselected [ 6 ] Selected [ 49 ]
-		// ================================================================================
-		// [ Immediate changes: ]
-		// --------------------------------------------------------------------------------
-		// [ All Actions ] [ 49 ] Unchanged [ 43 ] Changed [ 6 ]
-		// [ Class Action ] [ 41 ] Unchanged [ 38 ] Changed [ 3 ]
-		// [ Manifest Action ] [ 1 ] Unchanged [ 0 ] Changed [ 1 ]
-		// [ Service Config Action ] [ 7 ] Unchanged [ 5 ] Changed [ 2 ]
-		// ================================================================================
-		// [ Nested changes: ]
-		// --------------------------------------------------------------------------------
-		// [ ... ]
-		// ================================================================================
-		logger.info(consoleMarker, DASH_LINE);
+	public void log(Logger logger, String inputPath, String outputPath) {
+		if (logger.isDebugEnabled(consoleMarker)) {
+			// ================================================================================
+			// [ Input ] [ test.jar ]
+			// [
+			// c:\dev\jakarta-repo-pub\jakartaee-prototype\dev\transformer\app\test.jar
+			// ]
+			// [ Output ] [ output_test.jar ]
+			// [
+			// c:\dev\jakarta-repo-pub\jakartaee-prototype\dev\transformer\app\testOutput.jar
+			// ]
+			// ================================================================================
+			// [ All Resources ] [ 55 ] Unselected [ 6 ] Selected [ 49 ]
+			// ================================================================================
+			// [ Immediate changes: ]
+			// --------------------------------------------------------------------------------
+			// [ All Actions ] [ 49 ] Unchanged [ 43 ] Changed [ 6 ]
+			// [ Class Action ] [ 41 ] Unchanged [ 38 ] Changed [ 3 ]
+			// [ Manifest Action ] [ 1 ] Unchanged [ 0 ] Changed [ 1 ]
+			// [ Service Config Action ] [ 7 ] Unchanged [ 5 ] Changed [ 2 ]
+			// ================================================================================
+			// [ Nested changes: ]
+			// --------------------------------------------------------------------------------
+			// [ ... ]
+			// ================================================================================
+			logger.debug(consoleMarker, DASH_LINE);
 
-		logger.info(consoleMarker, "[ Input  ] [ {} ]", getInputResourceName());
-		logger.info(consoleMarker, "           [ {} ]", inputPath);
-		logger.info(consoleMarker, "[ Output ] [ {} ]", getOutputResourceName());
-		logger.info(consoleMarker, "           [ {} ]", outputPath);
-		logger.info(consoleMarker, DASH_LINE);
+			logger.debug(consoleMarker, "[ Input  ] [ {} ]", getInputResourceName());
+			logger.debug(consoleMarker, "           [ {} ]", inputPath);
+			logger.debug(consoleMarker, "[ Output ] [ {} ]", getOutputResourceName());
+			logger.debug(consoleMarker, "           [ {} ]", outputPath);
+			logger.debug(consoleMarker, DASH_LINE);
 
-		logger.info(consoleMarker, "[ Immediate changes: ]");
-		logger.info(consoleMarker, SMALL_DASH_LINE);
-		displayChanges(logger);
-		logger.info(consoleMarker, DASH_LINE);
+			logger.debug(consoleMarker, "[ Immediate changes: ]");
+			logger.debug(consoleMarker, SMALL_DASH_LINE);
+			displayChanges(logger);
+			logger.debug(consoleMarker, DASH_LINE);
 
-		if (allNestedChanges != null) {
-			logger.info(consoleMarker, "[ Nested changes: ]");
-			logger.info(consoleMarker, SMALL_DASH_LINE);
-			allNestedChanges.displayChanges(logger);
-			logger.info(consoleMarker, DASH_LINE);
-		}
-	}
-
-	@Override
-	public void displayTerse(Logger logger, String inputPath, String outputPath) {
-		if (!inputPath.equals(outputPath)) {
+			if (allNestedChanges != null) {
+				logger.debug(consoleMarker, "[ Nested changes: ]");
+				logger.debug(consoleMarker, SMALL_DASH_LINE);
+				allNestedChanges.displayChanges(logger);
+				logger.debug(consoleMarker, DASH_LINE);
+			}
+		} else if (logger.isInfoEnabled(consoleMarker)) {
 			if (!inputPath.equals(outputPath)) {
 				logger.info(consoleMarker, "Input [ {} ] as [ {} ]: {}", inputPath, outputPath, getChangeTag());
-			} else {
-				logger.info(consoleMarker, "Input [ {} ]: {}", inputPath, getChangeTag());
 			}
-		}
 
-		logger.info(consoleMarker,
-			formatData("All Resources", getAllResources(), "Unselected", getAllUnselected(), "Selected",
-			getAllSelected(), ""));
-		logger.info(consoleMarker,
-			formatData("All Actions", getAllSelected(), "Unchanged", getAllUnchanged(), "Changed",
-			getAllChanged(), ""));
-		if (allNestedChanges != null) {
-			logger.info(consoleMarker, formatData("Nested Resources", allNestedChanges.getAllResources(), "Unselected",
-				allNestedChanges.getAllUnselected(), "Selected", allNestedChanges.getAllSelected(), ""));
-			logger.info(consoleMarker, formatData("Nested Actions", allNestedChanges.getAllSelected(), "Unchanged",
-				allNestedChanges.getAllUnchanged(), "Changed", allNestedChanges.getAllChanged(), ""));
+			logger.info(consoleMarker, formatData("All Resources", getAllResources(), "Unselected", getAllUnselected(),
+				"Selected", getAllSelected(), ""));
+			logger.info(consoleMarker, formatData("All Actions", getAllSelected(), "Unchanged", getAllUnchanged(),
+				"Changed", getAllChanged(), ""));
+			if (allNestedChanges != null) {
+				logger.info(consoleMarker,
+					formatData("Nested Resources", allNestedChanges.getAllResources(), "Unselected",
+						allNestedChanges.getAllUnselected(), "Selected", allNestedChanges.getAllSelected(), ""));
+				logger.info(consoleMarker, formatData("Nested Actions", allNestedChanges.getAllSelected(), "Unchanged",
+					allNestedChanges.getAllUnchanged(), "Changed", allNestedChanges.getAllChanged(), ""));
+			}
 		}
 	}
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/DirectoryActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/DirectoryActionImpl.java
@@ -20,10 +20,10 @@ import org.slf4j.Logger;
 
 public class DirectoryActionImpl extends ContainerActionImpl {
 
-	public DirectoryActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public DirectoryActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/EarActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/EarActionImpl.java
@@ -15,10 +15,10 @@ import org.eclipse.transformer.action.ActionType;
 import org.slf4j.Logger;
 
 public class EarActionImpl extends ContainerActionImpl {
-	public EarActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public EarActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JarActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JarActionImpl.java
@@ -16,10 +16,10 @@ import org.slf4j.Logger;
 
 public class JarActionImpl extends ZipActionImpl {
 
-	public JarActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public JarActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JavaActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JavaActionImpl.java
@@ -31,10 +31,10 @@ import aQute.lib.io.ByteBufferOutputStream;
 
 public class JavaActionImpl extends ActionImpl {
 
-	public JavaActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public JavaActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//
@@ -156,14 +156,14 @@ public class JavaActionImpl extends ActionImpl {
 		try {
 			transform(reader, writer); // throws IOException
 		} catch (IOException e) {
-			error("Failed to transform [ {} ]", e, inputName);
+			getLogger().error("Failed to transform [ {} ]", inputName, e);
 			return null;
 		}
 
 		try {
 			writer.flush(); // throws
 		} catch (IOException e) {
-			error("Failed to flush [ {} ]", e, inputName);
+			getLogger().error("Failed to flush [ {} ]", inputName, e);
 			return null;
 		}
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/NullActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/NullActionImpl.java
@@ -20,10 +20,10 @@ import org.slf4j.Logger;
 
 public class NullActionImpl extends ActionImpl {
 
-	public NullActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public NullActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
@@ -21,10 +21,10 @@ import org.slf4j.Logger;
  */
 public class PropertiesActionImpl extends ActionImpl {
 
-	public PropertiesActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public PropertiesActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	@Override
@@ -37,7 +37,7 @@ public class PropertiesActionImpl extends ActionImpl {
 
 		String outputName = transformBinaryType(inputName);
 		if (outputName != null) {
-			verbose("Properties file %s, relocated to %s", inputName, outputName);
+			getLogger().debug("Properties file {}, relocated to {}", inputName, outputName);
 			setResourceNames(inputName, outputName);
 			return new ByteData(outputName, inputBytes, 0, inputLength);
 		} else {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/RarActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/RarActionImpl.java
@@ -15,10 +15,10 @@ import org.eclipse.transformer.action.ActionType;
 import org.slf4j.Logger;
 
 public class RarActionImpl extends ContainerActionImpl {
-	public RarActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public RarActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
@@ -47,10 +47,10 @@ public class ServiceLoaderConfigActionImpl extends ActionImpl {
 
 	//
 
-	public ServiceLoaderConfigActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public ServiceLoaderConfigActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//
@@ -111,7 +111,7 @@ public class ServiceLoaderConfigActionImpl extends ActionImpl {
 		if (outputName == null) {
 			outputName = inputName;
 		} else {
-			verbose("Service name  [ {} ] -> [ {} ]", inputName, outputName);
+			getLogger().debug("Service name  [ {} ] -> [ {} ]", inputName, outputName);
 		}
 		setResourceNames(inputName, outputName);
 
@@ -128,14 +128,14 @@ public class ServiceLoaderConfigActionImpl extends ActionImpl {
 		try {
 			transform(reader, writer); // throws IOException
 		} catch (IOException e) {
-			error("Failed to transform [ {} ]", e, inputName);
+			getLogger().error("Failed to transform [ {} ]", inputName, e);
 			return null;
 		}
 
 		try {
 			writer.flush(); // throws
 		} catch (IOException e) {
-			error("Failed to flush [ {} ]", e, inputName);
+			getLogger().error("Failed to flush [ {} ]", inputName, e);
 			return null;
 		}
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigChangesImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigChangesImpl.java
@@ -62,10 +62,13 @@ public class ServiceLoaderConfigChangesImpl extends ChangesImpl {
 	//
 
 	@Override
-	public void displayVerbose(Logger logger, String inputPath, String outputPath) {
-		logger.info(consoleMarker, "Input  [ {} ] as [ {} ]", getInputResourceName(), inputPath);
-		logger.info(consoleMarker, "Output [ {} ] as [ {} ]", getOutputResourceName(), outputPath);
-		logger.info(consoleMarker, "Replacements [ {} ]", getChangedProviders());
+	public void log(Logger logger, String inputPath, String outputPath) {
+		if (logger.isDebugEnabled(consoleMarker)) {
+			logger.debug(consoleMarker, "Input  [ {} ] as [ {} ]", getInputResourceName(), inputPath);
+			logger.debug(consoleMarker, "Output [ {} ] as [ {} ]", getOutputResourceName(), outputPath);
+			logger.debug(consoleMarker, "Replacements [ {} ]", getChangedProviders());
+		} else {
+			super.log(logger, inputPath, outputPath);
+		}
 	}
-
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
@@ -31,10 +31,10 @@ import aQute.lib.io.ByteBufferOutputStream;
 
 public class TextActionImpl extends ActionImpl {
 
-	public TextActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public TextActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//
@@ -84,14 +84,14 @@ public class TextActionImpl extends ActionImpl {
 		try {
 			transform(inputName, reader, writer); // throws IOException
 		} catch (IOException e) {
-			error("Failed to transform [ {} ]", e, inputName);
+			getLogger().error("Failed to transform [ {} ]", inputName, e);
 			return null;
 		}
 
 		try {
 			writer.flush(); // throws
 		} catch (IOException e) {
-			error("Failed to flush [ {} ]", e, inputName);
+			getLogger().error("Failed to flush [ {} ]", inputName, e);
 			return null;
 		}
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/WarActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/WarActionImpl.java
@@ -15,10 +15,10 @@ import org.eclipse.transformer.action.ActionType;
 import org.slf4j.Logger;
 
 public class WarActionImpl extends ContainerActionImpl {
-	public WarActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public WarActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
@@ -40,10 +40,10 @@ import aQute.lib.io.ByteBufferOutputStream;
 
 public class XmlActionImpl extends ActionImpl {
 
-	public XmlActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public XmlActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//
@@ -126,14 +126,14 @@ public class XmlActionImpl extends ActionImpl {
 			transformAsPlainText(inputName, reader, writer); // throws
 																// IOException
 		} catch (IOException e) {
-			error("Failed to transform [ {} ]", e, inputName);
+			getLogger().error("Failed to transform [ {} ]", inputName, e);
 			return null;
 		}
 
 		try {
 			writer.flush(); // throws
 		} catch (IOException e) {
-			error("Failed to flush [ {} ]", e, inputName);
+			getLogger().error("Failed to flush [ {} ]", inputName, e);
 			return null;
 		}
 
@@ -298,19 +298,19 @@ public class XmlActionImpl extends ActionImpl {
 		}
 
 		protected void appendLine(char c) {
-			lineBuilder.append(c);
-			lineBuilder.append('\n');
+			lineBuilder.append(c)
+				.append('\n');
 		}
 
 		protected void append(String text) {
-			debug("appending [" + text + "]");
+			getLogger().debug("append [{}]", text);
 			lineBuilder.append(text);
 		}
 
 		protected void appendLine(String text) {
-			debug("appendline[" + text + "]");
-			lineBuilder.append(text);
-			lineBuilder.append('\n');
+			getLogger().debug("appendline [{}]", text);
+			lineBuilder.append(text)
+				.append('\n');
 		}
 
 		protected void emit() throws SAXException {
@@ -352,7 +352,7 @@ public class XmlActionImpl extends ActionImpl {
 			append("<?");
 			append(target);
 			if ((data != null) && data.length() > 0) {
-				debug("processingInstruction: data[" + data + "]");
+				getLogger().debug("processingInstruction: data[{}]", data);
 				append(' ');
 				append(data);
 			}
@@ -378,8 +378,8 @@ public class XmlActionImpl extends ActionImpl {
 		@Override
 		public void startElement(String uri, String localName, String qName, Attributes attributes)
 			throws SAXException {
-			debug("startElement: uri[" + uri + "] localName[" + localName + "] qName[" + qName + "] attributes["
-				+ attributes + "]");
+			getLogger().debug("startElement: uri[{}] localName[{}] qName[{}] attributes[{}]", uri, localName, qName,
+				attributes);
 			append('<' + localName);
 			append(uri);
 
@@ -388,10 +388,10 @@ public class XmlActionImpl extends ActionImpl {
 				for (int i = 0; i < numberAttributes; i++) {
 					append(' ');
 					append(attributes.getQName(i));
-					debug("startElement: attributes.getQName(" + i + ")[" + attributes.getQName(i) + "]");
+					getLogger().debug("startElement: attributes.getQName({})[{}]", i, attributes.getQName(i));
 					append("=\"");
 					append(attributes.getValue(i));
-					debug("startElement: attributes.getValue(" + i + ")[" + attributes.getValue(i) + "]");
+					getLogger().debug("startElement: attributes.getValue({})[{}]", i, attributes.getValue(i));
 					append('"');
 				}
 			}
@@ -404,7 +404,7 @@ public class XmlActionImpl extends ActionImpl {
 		@SuppressWarnings("unused")
 		@Override
 		public void endElement(String uri, String localName, String qName) throws SAXException {
-			debug("endElement: uri[" + uri + "] localName[" + localName + "] qName[" + qName + "]");
+			getLogger().debug("endElement: uri[{}] localName[{}] qName[{}]", uri, localName, qName);
 			append("</");
 			append(localName + '>');
 		}
@@ -413,7 +413,7 @@ public class XmlActionImpl extends ActionImpl {
 		@Override
 		public void characters(char[] chars, int start, int length) throws SAXException {
 			String initialText = new String(chars, start, length);
-			debug("characters: initialText[" + initialText + "]");
+			getLogger().debug("characters: initialText[{}]", initialText);
 
 			String finalText = XmlActionImpl.this.replaceText(inputName, initialText);
 			if (finalText == null) {
@@ -421,7 +421,7 @@ public class XmlActionImpl extends ActionImpl {
 				XmlActionImpl.this.addReplacement();
 			}
 
-			debug("characters:  finalText[" + finalText + "]");
+			getLogger().debug("characters:  finalText[{}]", finalText);
 			append(finalText);
 		}
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
@@ -16,10 +16,10 @@ import org.slf4j.Logger;
 
 public class ZipActionImpl extends ContainerActionImpl {
 
-	public ZipActionImpl(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+	public ZipActionImpl(Logger logger, InputBufferImpl buffer,
 		SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule) {
 
-		super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule);
+		super(logger, buffer, selectionRule, signatureRule);
 	}
 
 	//

--- a/org.eclipse.transformer/src/test/java/org/eclipse/transformer/action/impl/ClassActionTest.java
+++ b/org.eclipse.transformer/src/test/java/org/eclipse/transformer/action/impl/ClassActionTest.java
@@ -116,7 +116,7 @@ public class ClassActionTest {
 		renames.put("original.provides", "transformed.provides");
 		renames.put("original.provides.impl", "transformed.provides.impl");
 		renames.put("original.main", "transformed.main");
-		Action classAction = new ClassActionImpl(logger, false, false, new InputBufferImpl(),
+		Action classAction = new ClassActionImpl(logger, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
 		classAction.apply(testName, inputStream, inputStream.available(), outputStream);
@@ -211,7 +211,7 @@ public class ClassActionTest {
 		Map<String, String> renames = new HashMap<>();
 		renames.put("original.host", "transformed.host");
 		renames.put("original.member", "transformed.member");
-		Action classAction = new ClassActionImpl(logger, false, false, new InputBufferImpl(),
+		Action classAction = new ClassActionImpl(logger, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
 		classAction.apply(testName, inputStream, inputStream.available(), outputStream);
@@ -254,7 +254,7 @@ public class ClassActionTest {
 		renames.put("original.enclosing", "transformed.enclosing");
 		renames.put("original.param", "transformed.param");
 		renames.put("original.result", "transformed.result");
-		Action classAction = new ClassActionImpl(logger, false, false, new InputBufferImpl(),
+		Action classAction = new ClassActionImpl(logger, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
 		classAction.apply(testName, inputStream, inputStream.available(), outputStream);

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
@@ -325,7 +325,7 @@ public class TestTransformClass extends CaptureTest {
 		if (toJakartaJarAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			toJakartaJarAction = new JarActionImpl(useLogger, false, false, createBuffer(),
+			toJakartaJarAction = new JarActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getToJakartaRenames(), null, null, null, Collections.emptyMap()));
 		}
@@ -341,7 +341,7 @@ public class TestTransformClass extends CaptureTest {
 
 			Map<String, String> toJavaxRenames = TransformProperties.invert(getToJakartaRenames());
 
-			toJavaxJarAction = new JarActionImpl(useLogger, false, false, createBuffer(),
+			toJavaxJarAction = new JarActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, toJavaxRenames, null, null, null, Collections.emptyMap()));
 		}
@@ -355,7 +355,7 @@ public class TestTransformClass extends CaptureTest {
 		if (toJakartaJarAction_DirectOverride == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			toJakartaJarAction_DirectOverride = new JarActionImpl(useLogger, false, false, createBuffer(),
+			toJakartaJarAction_DirectOverride = new JarActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getOverrideIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getToJakartaRenames(), null, null, toJakartaDirectStrings(), null));
 		}
@@ -369,7 +369,7 @@ public class TestTransformClass extends CaptureTest {
 		if (toJakartaJarAction_PerClassDirectOverride == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			toJakartaJarAction_PerClassDirectOverride = new JarActionImpl(useLogger, false, false, createBuffer(),
+			toJakartaJarAction_PerClassDirectOverride = new JarActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getOverrideIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getToJakartaRenames(), null, null, toJakartaDirectStrings(),
 					toJakartaPerClassDirectStrings()));
@@ -474,7 +474,7 @@ public class TestTransformClass extends CaptureTest {
 	public ClassActionImpl createToJakartaClassAction() {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		return new ClassActionImpl(useLogger, false, false, createBuffer(),
+		return new ClassActionImpl(useLogger, createBuffer(),
 			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
 			createSignatureRule(useLogger, getToJakartaRenames(), null, null, null, Collections.emptyMap()));
 	}
@@ -780,7 +780,7 @@ public class TestTransformClass extends CaptureTest {
 	public ClassActionImpl createDirectClassAction() {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		return new ClassActionImpl(useLogger, false, false, createBuffer(),
+		return new ClassActionImpl(useLogger, createBuffer(),
 			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
 			createSignatureRule(useLogger, Collections.emptyMap(), null, null, getDirectStrings(), Collections.emptyMap()));
 	}
@@ -788,7 +788,7 @@ public class TestTransformClass extends CaptureTest {
 	public ClassActionImpl createPerClassConstantClassAction() {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		return new ClassActionImpl(useLogger, false, false, createBuffer(),
+		return new ClassActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
 				createSignatureRule(useLogger, Collections.emptyMap(), null, null, null, PER_CLASS_CONSTANT_MASTER));
 	}
@@ -1077,7 +1077,7 @@ public class TestTransformClass extends CaptureTest {
 	public ClassActionImpl createStandardClassAction() throws IOException {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		return new ClassActionImpl(useLogger, false, false, createBuffer(),
+		return new ClassActionImpl(useLogger, createBuffer(),
 			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
 			createSignatureRule(useLogger, getStandardRenames(), null, null, null, Collections.emptyMap()));
 		// 'getStandardRenames' throws IOException

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
@@ -246,7 +246,7 @@ public class TestTransformManifest extends CaptureTest {
 		if (jakartaManifestAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			jakartaManifestAction = new ManifestActionImpl(useLogger, false, false, new InputBufferImpl(),
+			jakartaManifestAction = new ManifestActionImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), null, getBundleUpdates(), null, getDirectStrings(),
 					Collections.emptyMap()),
@@ -261,7 +261,7 @@ public class TestTransformManifest extends CaptureTest {
 		if (jakartaFeatureAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			jakartaFeatureAction = new ManifestActionImpl(useLogger, false, false, new InputBufferImpl(),
+			jakartaFeatureAction = new ManifestActionImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, null, null, null,
 					Collections.emptyMap()),
@@ -279,7 +279,7 @@ public class TestTransformManifest extends CaptureTest {
 		if (jakartaManifestActionTx == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			jakartaManifestActionTx = new ManifestActionImpl(useLogger, false, false, new InputBufferImpl(),
+			jakartaManifestActionTx = new ManifestActionImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), null, getBundleUpdatesTx(), null, getDirectStrings(),
 					Collections.emptyMap()),
@@ -294,7 +294,7 @@ public class TestTransformManifest extends CaptureTest {
 		if (specificJakartaManifestAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			specificJakartaManifestAction = new ManifestActionImpl(useLogger, false, false, new InputBufferImpl(),
+			specificJakartaManifestAction = new ManifestActionImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), getSpecificPackageVersions(), getBundleUpdatesTx(),
 					null, getDirectStrings(), Collections.emptyMap()),
@@ -671,10 +671,10 @@ public class TestTransformManifest extends CaptureTest {
 	 * Subclass which allows us to call protected methods of ManifestActionImpl
 	 */
 	class ManifestActionImpl_Test extends ManifestActionImpl {
-		public ManifestActionImpl_Test(Logger logger, boolean isTerse, boolean isVerbose, InputBufferImpl buffer,
+		public ManifestActionImpl_Test(Logger logger, InputBufferImpl buffer,
 			SelectionRuleImpl selectionRule, SignatureRuleImpl signatureRule, boolean isManifest) {
 
-			super(logger, isTerse, isVerbose, buffer, selectionRule, signatureRule, isManifest);
+			super(logger, buffer, selectionRule, signatureRule, isManifest);
 		}
 
 		public boolean callIsTrueMatch(String text, int matchStart, int keyLen) {
@@ -700,7 +700,7 @@ public class TestTransformManifest extends CaptureTest {
 		if (manifestAction_test == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			manifestAction_test = new ManifestActionImpl_Test(useLogger, false, false, new InputBufferImpl(),
+			manifestAction_test = new ManifestActionImpl_Test(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, null, null, null,
 					Collections.emptyMap()),
@@ -716,7 +716,7 @@ public class TestTransformManifest extends CaptureTest {
 		if (specificManifestAction_test == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			specificManifestAction_test = new ManifestActionImpl_Test(useLogger, false, false, new InputBufferImpl(),
+			specificManifestAction_test = new ManifestActionImpl_Test(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), getSpecificPackageVersions(),

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
@@ -93,7 +93,7 @@ public class TestTransformPropertiesFile extends CaptureTest {
 		if (jakartaPropertiesAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			jakartaPropertiesAction = new PropertiesActionImpl(useLogger, false, false, createBuffer(),
+			jakartaPropertiesAction = new PropertiesActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getPackageRenames()));
 		}

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
@@ -159,7 +159,7 @@ public class TestTransformServiceConfig extends CaptureTest {
 		if (jakartaServiceAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			jakartaServiceAction = new ServiceLoaderConfigActionImpl(useLogger, false, false, createBuffer(),
+			jakartaServiceAction = new ServiceLoaderConfigActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getPackageRenames(), null, null, null));
 		}
@@ -172,7 +172,7 @@ public class TestTransformServiceConfig extends CaptureTest {
 
 			Map<String, String> invertedRenames = TransformProperties.invert(getPackageRenames());
 
-			javaxServiceAction = new ServiceLoaderConfigActionImpl(useLogger, false, false, createBuffer(),
+			javaxServiceAction = new ServiceLoaderConfigActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, invertedRenames, null, null, null));
 		}
@@ -185,11 +185,11 @@ public class TestTransformServiceConfig extends CaptureTest {
 
 			Map<String, String> invertedRenames = TransformProperties.invert(getPackageRenames());
 
-			CompositeActionImpl useRootAction = new CompositeActionImpl(useLogger, false, false, createBuffer(),
+			CompositeActionImpl useRootAction = new CompositeActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, Collections.emptySet(), getExcludes()),
 				createSignatureRule(useLogger, invertedRenames, null, null, null));
 
-			jarJavaxServiceAction = new JarActionImpl(useLogger, false, false, createBuffer(),
+			jarJavaxServiceAction = new JarActionImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, Collections.emptySet(), getExcludes()),
 				createSignatureRule(useLogger, invertedRenames, null, null, null));
 

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
@@ -103,7 +103,7 @@ public class TestTransformXML extends CaptureTest {
 		if (textAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			textAction = new TextActionImpl(useLogger, false, false, new InputBufferImpl(),
+			textAction = new TextActionImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger, null, null, null, null, getMasterXmlUpdates(), null,
 					Collections.emptyMap()));


### PR DESCRIPTION
We now use `--verbose` or `--quiet` in the CLI to configure the log level
of the Logger passed to Transformer. For `--verbose` , the CLI will
configure the log level DEBUG. For `--quiet`, the CLI will configure the
log level ERROR.

In the lib code, we simply use `debug` level for verbose output, `info` for
normal output which wont be displayed if `--quiet` is specified to the
CLI which sets the log level to ERROR.

This then means we do not leak the CLI's verbose and quiet abstractions
into the lib code. Users of the lib code are free to configure log
levels as they see fit with out also needing to configure the verbose or
quiet app options.

We also use the Logger API directly in the code instead of having our
own "wrapper" methods. This allows for more efficient calling of logging
since we can avoid Object[] in many cases since we don't need to use the
varargs methods. We also pass any exception to the logger as excess
arguments rather than having our own special handling code. This allows
the logger implementation to handle exceptions in its own way.