### PR TITLE
deps: Fix slf4j-simple dependency

### DIFF
--- a/org.eclipse.transformer.cli/pom.xml
+++ b/org.eclipse.transformer.cli/pom.xml
@@ -47,6 +47,11 @@
 			<artifactId>commons-cli</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-simple</artifactId>
 				<version>1.7.32</version>
-				<scope>runtime</scope>
+				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>

--- a/transformer-maven-plugin/pom.xml
+++ b/transformer-maven-plugin/pom.xml
@@ -74,6 +74,10 @@
 
 		<!-- TESTS -->
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.plugin-testing</groupId>
 			<artifactId>maven-plugin-testing-harness</artifactId>
 		</dependency>


### PR DESCRIPTION
It is not a runtime dependency of the lib. It is only a test dependency.
For the cli, an slf4j impl is necessary, so we have a runtime scope
dependency for cli. We also add it as a test dependency for the
maven plugin project's tests.

