### PR TITLE
build: Revert maven-plugin-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
-					<version>3.6.2</version>
+					<version>3.6.1</version>
 					<executions>
 						<execution>
 							<id>default-descriptor</id>


### PR DESCRIPTION
See if this fixes the plugin section of maven-metadata to contain
the goal prefix.

