### PR TITLE
maven: Remove unneeded configuration for maven-plugin-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,22 +266,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
 					<version>3.6.1</version>
-					<executions>
-						<execution>
-							<id>default-descriptor</id>
-							<phase>process-classes</phase>
-							<goals>
-								<goal>descriptor</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>default-addPluginArtifactMetadata</id>
-							<phase>package</phase>
-							<goals>
-								<goal>addPluginArtifactMetadata</goal>
-							</goals>
-						</execution>
-					</executions>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -455,7 +439,7 @@
 			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
-				<version>3.3</version>
+				<version>3.6.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This is no longer needed since Maven 3.2.5 and we currently use
3.8.4. We also update the maven-plugins-annotations version.
