### PR TITLE
feat: add jbang-catalog

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,20 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "transformer": {
+      "script-ref": "org.eclipse.transformer:org.eclipse.transformer.cli:0.3.0-SNAPSHOT",
+      "repositories": [
+        "https://oss.sonatype.org/content/repositories/snapshots"
+      ],
+      "main": "org.eclipse.transformer.cli.TransformerCLI"
+    },
+    "jakartatransformer": {
+      "script-ref": "org.eclipse.transformer:org.eclipse.transformer.cli:0.3.0-SNAPSHOT",
+      "repositories": [
+        "https://oss.sonatype.org/content/repositories/snapshots"
+      ],
+      "main": "org.eclipse.transformer.cli.JakartaTransformerCLI"
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
Add jbang-catalog to allow easily run transformer using jbang.dev

for now, you can run it just from the branch:

    $ jbang jakartatransformer@maxandersen/transformer/jbang

But once this is merged the following will work:

    $ jbang jakartatransformer@eclipse/transformer

would be nice if eclipse/jbang-catalog existed then we could do it using 

    $ jbang jakartatransformer@eclipse

But for now this will do I reckon.

Signed-off-by: Max Rydahl Andersen <manderse@redhat.com>
