### PR TITLE
ci: Reactor poms do not inherit from parent pom

### DIFF
--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -13,14 +13,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.eclipse.transformer</groupId>
-		<artifactId>org.eclipse.transformer.parent</artifactId>
-		<version>${revision}</version>
-		<relativePath>../org.eclipse.transformer.parent</relativePath>
-	</parent>
 
+	<groupId>org.eclipse.transformer</groupId>
 	<artifactId>maven-plugins</artifactId>
+	<version>1.0.0</version>
 	<description>Eclipse Transformer Maven Plugins Build Reactor</description>
 	<packaging>pom</packaging>
 	<name>${project.groupId}:${project.artifactId}</name>
@@ -28,7 +24,6 @@
 	<properties>
 		<maven.install.skip>true</maven.install.skip>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
 	</properties>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.eclipse.transformer</groupId>
-		<artifactId>org.eclipse.transformer.parent</artifactId>
-		<version>${revision}</version>
-		<relativePath>org.eclipse.transformer.parent</relativePath>
-	</parent>
-
+	<groupId>org.eclipse.transformer</groupId>
 	<artifactId>build</artifactId>
+	<version>1.0.0</version>
 	<description>Eclipse Transformer Build Reactor</description>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>pom</packaging>
@@ -29,7 +24,6 @@
 	<properties>
 		<maven.install.skip>true</maven.install.skip>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
 	</properties>
 
 	<modules>
@@ -39,5 +33,4 @@
 		<module>org.eclipse.transformer.cli</module>
 		<module>maven-plugins</module>
 	</modules>
-
 </project>


### PR DESCRIPTION
This is necessary to ensure they are not deployed by the
nexus-staging-maven-plugin.

