### PR TITLE
Fix #293 Converting a text file which is not encoded in UTF-8 causes garbled characters

### DIFF
--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
@@ -84,7 +84,9 @@ public enum AppOption {
 
 	RULES_PER_CLASS_CONSTANT(
 		new Settings("tp", "per-class-constant", "Transformation per class constant string replacements",
-			Settings.HAS_ARG, !Settings.HAS_ARGS, !Settings.IS_REQUIRED, Settings.NO_GROUP));
+			Settings.HAS_ARG, !Settings.HAS_ARGS, !Settings.IS_REQUIRED, Settings.NO_GROUP)),
+	ENCODING(
+		new Settings("enc", "encoding", "File encoding (default: UTF-8)", Settings.HAS_ARG, !Settings.HAS_ARGS, !Settings.IS_REQUIRED, Settings.NO_GROUP));
 
 	AppOption(Settings settings) {
 		this.settings = settings;

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -12,6 +12,7 @@
 package org.eclipse.transformer;
 
 import static aQute.bnd.exceptions.BiFunctionWithException.asBiFunction;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -19,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -136,6 +138,7 @@ public class Transformer {
 	public String							outputPath;
 	public File								outputFile;
 	public Map<String, Map<String, String>> perClassConstantStrings;
+	public Charset							encoding	= UTF_8;
 
 	//
 
@@ -163,6 +166,13 @@ public class Transformer {
 		}
 		if (!setOutput()) {
 			return ResultCode.TRANSFORM_ERROR_RC;
+		}
+		
+		try {
+			setEncoding();
+		} catch (Exception e) {
+			getLogger().error(consoleMarker, "Encoding type error:", e);
+			return ResultCode.ARGS_ERROR_RC;
 		}
 
 		boolean loadedRules;
@@ -230,6 +240,13 @@ public class Transformer {
 
 	public String getOutputFileName() {
 		return outputName;
+	}
+
+	public void setEncoding() {
+		if (options.hasOption(AppOption.ENCODING)) {
+			String encoding = options.getOptionValue(AppOption.ENCODING);
+			this.encoding = Charset.forName(encoding);
+		}
 	}
 
 	/**
@@ -1132,6 +1149,15 @@ public class Transformer {
 			ContainerAction zipAction = useSelector.addUsing(ZipActionImpl::newZipAction, initData);
 
 			Action renameAction = useSelector.addUsing(RenameActionImpl::new, initData);
+
+			classAction.setEncoding(encoding);
+			javaAction.setEncoding(encoding);
+			jspAction.setEncoding(encoding);
+			serviceConfigAction.setEncoding(encoding);
+			manifestAction.setEncoding(encoding);
+			featureAction.setEncoding(encoding);
+			textAction.setEncoding(encoding);
+			propertiesAction.setEncoding(encoding);
 
 			// Directory actions know about all actions except for directory
 			// actions, and except for the properties action.

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
@@ -12,6 +12,7 @@
 package org.eclipse.transformer.action;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 import org.eclipse.transformer.TransformException;
 import org.slf4j.Logger;
@@ -34,6 +35,10 @@ public interface Action {
 	 * @return The type of this action.
 	 */
 	ActionType getActionType();
+
+	Charset getEncoding();
+	
+	void setEncoding(Charset encoding); 
 
 	/**
 	 * Tell if this is an element type action.

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ByteData.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ByteData.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 /**
  * A byte data buffer.
@@ -68,7 +69,7 @@ public interface ByteData {
 	 *
 	 * @return A reader on this buffer.
 	 */
-	BufferedReader reader();
+	BufferedReader reader(Charset encoding);
 
 	/**
 	 * Copy this byte data to an output stream.

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
@@ -11,10 +11,13 @@
 
 package org.eclipse.transformer.action.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -153,6 +156,18 @@ public abstract class ActionImpl implements Action {
 	public abstract ActionType getActionType();
 
 	//
+
+	private Charset encoding = UTF_8;
+
+	@Override
+	public Charset getEncoding() {
+		return encoding;
+	}
+
+	@Override
+	public void setEncoding(Charset encoding) {
+		this.encoding = encoding;
+	}
 
 	private final SelectionRule resourceSelectionRule;
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ByteDataImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ByteDataImpl.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.util.FileUtils;
@@ -69,8 +70,8 @@ public class ByteDataImpl implements ByteData {
 	//
 
 	@Override
-	public BufferedReader reader() {
-		return FileUtils.reader(buffer());
+	public BufferedReader reader(Charset encoding) {
+		return FileUtils.reader(buffer(), encoding);
 	}
 
 	@Override

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
@@ -11,10 +11,13 @@
 
 package org.eclipse.transformer.action.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.ActionType;
@@ -111,7 +114,7 @@ public class ServiceLoaderConfigActionImpl extends ElementActionImpl {
 
 			ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 
-			try (BufferedReader reader = inputData.reader(); BufferedWriter writer = FileUtils.writer(outputStream)) {
+			try (BufferedReader reader = inputData.reader(getEncoding()); BufferedWriter writer = FileUtils.writer(outputStream, getEncoding())) {
 				transform(reader, writer);
 			} catch (IOException e) {
 				throw new TransformException("Failed to transform [ " + inputName + " ]", e);

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.transformer.action.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -93,7 +95,7 @@ public class TextActionImpl extends ElementActionImpl {
 
 			ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 
-			try (BufferedReader reader = inputData.reader(); BufferedWriter writer = FileUtils.writer(outputStream)) {
+			try (BufferedReader reader = inputData.reader(getEncoding()); BufferedWriter writer = FileUtils.writer(outputStream, getEncoding())) {
 				transform(inputName, reader, writer);
 			} catch (IOException e) {
 				throw new TransformException("Failed to transform [ " + inputName + " ]", e);

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
@@ -136,7 +136,7 @@ public class XmlActionImpl extends ElementActionImpl {
 
 		ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 
-		try (BufferedReader reader = inputData.reader(); BufferedWriter writer = FileUtils.writer(outputStream)) {
+		try (BufferedReader reader = inputData.reader(getEncoding()); BufferedWriter writer = FileUtils.writer(outputStream, getEncoding())) {
 			transformAsPlainText(inputName, reader, writer);
 		} catch (IOException e) {
 			throw new TransformException("Failed to transform [ " + inputName + " ]", e);
@@ -202,7 +202,7 @@ public class XmlActionImpl extends ElementActionImpl {
 
 	public void transform(String inputName, InputStream input, OutputStream output) throws TransformException {
 		InputSource inputSource = new InputSource(input);
-		inputSource.setEncoding(UTF_8.name());
+		inputSource.setEncoding(getEncoding().name());
 
 		XMLContentHandler handler = new XMLContentHandler(inputName, inputSource, output);
 
@@ -223,7 +223,7 @@ public class XmlActionImpl extends ElementActionImpl {
 	public void transformUsingSaxParser(String inputName, InputStream input, OutputStream output)
 		throws TransformException {
 		InputSource inputSource = new InputSource(input);
-		inputSource.setEncoding(UTF_8.name());
+		inputSource.setEncoding(getEncoding().name());
 
 		XMLContentHandler handler = new XMLContentHandler(inputName, inputSource, output);
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/util/FileUtils.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/util/FileUtils.java
@@ -11,8 +11,6 @@
 
 package org.eclipse.transformer.util;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -20,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.regex.Pattern;
@@ -307,13 +306,13 @@ public class FileUtils {
 		return new ByteBufferInputStream(byteData.buffer());
 	}
 
-	public static BufferedReader reader(ByteBuffer buffer) {
-		BufferedReader reader = IO.reader(buffer, UTF_8);
+	public static BufferedReader reader(ByteBuffer buffer, Charset encoding) {
+		BufferedReader reader = IO.reader(buffer, encoding);
 		return reader;
 	}
 
-	public static BufferedWriter writer(OutputStream outputStream) {
-		OutputStreamWriter outputWriter = new OutputStreamWriter(outputStream, UTF_8);
+	public static BufferedWriter writer(OutputStream outputStream, Charset encoding) {
+		OutputStreamWriter outputWriter = new OutputStreamWriter(outputStream, encoding);
 		BufferedWriter writer = new BufferedWriter(outputWriter);
 		return writer;
 	}


### PR DESCRIPTION
* Fixes #293

Signed-off-by: Ryosuke Okada <ryosuke.okada@fujitsu.com>