### PR TITLE
Add encoding support using the selection rules

### DIFF
--- a/bnd-plugins/org.eclipse.transformer.bnd.analyzer/src/main/java/org/eclipse/transformer/bnd/analyzer/BaseTransformerPlugin.java
+++ b/bnd-plugins/org.eclipse.transformer.bnd.analyzer/src/main/java/org/eclipse/transformer/bnd/analyzer/BaseTransformerPlugin.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import org.eclipse.transformer.AppOption;
 import org.eclipse.transformer.TransformOptions;
 import org.eclipse.transformer.Transformer;
-import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionSelector;
 import org.eclipse.transformer.action.ContainerChanges;
 import org.eclipse.transformer.bnd.analyzer.action.AnalyzerAction;
@@ -93,9 +93,9 @@ public class BaseTransformerPlugin implements Plugin {
 		// See issue #296
 
 		ActionSelector actionSelector = transformer.getActionSelector();
-		Action.ActionInitData initData = transformer.getActionInitData();
+		ActionContext context = transformer.getActionContext();
 		boolean overwrite = options.hasOption(AppOption.OVERWRITE);
-		AnalyzerAction analyzerAction = new AnalyzerAction(initData, actionSelector, overwrite);
+		AnalyzerAction analyzerAction = new AnalyzerAction(context, actionSelector, overwrite);
 
 		analyzerAction.apply(analyzer);
 

--- a/bnd-plugins/org.eclipse.transformer.bnd.analyzer/src/main/java/org/eclipse/transformer/bnd/analyzer/action/AnalyzerAction.java
+++ b/bnd-plugins/org.eclipse.transformer.bnd.analyzer/src/main/java/org/eclipse/transformer/bnd/analyzer/action/AnalyzerAction.java
@@ -20,6 +20,7 @@ import java.util.jar.Manifest;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionSelector;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
@@ -37,8 +38,8 @@ import aQute.bnd.osgi.Resource;
 public class AnalyzerAction extends ContainerActionImpl {
 	private final boolean		overwrite;
 
-	public AnalyzerAction(ActionInitData initData, ActionSelector actionSelector, boolean overwrite) {
-		super(initData, actionSelector);
+	public AnalyzerAction(ActionContext context, ActionSelector actionSelector, boolean overwrite) {
+		super(context, actionSelector);
 		this.overwrite = overwrite;
 	}
 

--- a/bnd-plugins/org.eclipse.transformer.bnd.analyzer/src/main/java/org/eclipse/transformer/bnd/analyzer/action/AnalyzerAction.java
+++ b/bnd-plugins/org.eclipse.transformer.bnd.analyzer/src/main/java/org/eclipse/transformer/bnd/analyzer/action/AnalyzerAction.java
@@ -13,6 +13,7 @@ package org.eclipse.transformer.bnd.analyzer.action;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -101,7 +102,8 @@ public class AnalyzerAction extends ContainerActionImpl {
 					ByteBuffer bb = resource.buffer();
 					ByteData inputData;
 					if (bb != null) {
-						inputData = new ByteDataImpl(inputPath, bb);
+						Charset charset = resourceCharset(inputPath);
+						inputData = new ByteDataImpl(inputPath, bb, charset);
 					} else {
 						inputData = collect(inputPath, resource.openInputStream(),
 							Math.toIntExact(resource.size()));

--- a/maven-plugins/transformer-maven-plugin/src/main/java/org/eclipse/transformer/maven/AbstractTransformerMojo.java
+++ b/maven-plugins/transformer-maven-plugin/src/main/java/org/eclipse/transformer/maven/AbstractTransformerMojo.java
@@ -113,7 +113,7 @@ public abstract class AbstractTransformerMojo extends AbstractMojo {
 		}
 		transformer.logRules();
 
-		TransformerJarAction action = new TransformerJarAction(transformer.getActionInitData(),
+		TransformerJarAction action = new TransformerJarAction(transformer.getActionContext(),
 			transformer.getActionSelector(),
 			options.hasOption(AppOption.OVERWRITE));
 		action.apply(jar, inputName, outputName);

--- a/maven-plugins/transformer-maven-plugin/src/main/java/org/eclipse/transformer/maven/action/TransformerJarAction.java
+++ b/maven-plugins/transformer-maven-plugin/src/main/java/org/eclipse/transformer/maven/action/TransformerJarAction.java
@@ -13,6 +13,7 @@ package org.eclipse.transformer.maven.action;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -113,7 +114,8 @@ public class TransformerJarAction extends ContainerActionImpl {
 					ByteBuffer bb = resource.buffer();
 					ByteData inputData;
 					if (bb != null) {
-						inputData = new ByteDataImpl(inputPath, bb);
+						Charset charset = resourceCharset(inputPath);
+						inputData = new ByteDataImpl(inputPath, bb, charset);
 					} else {
 						inputData = collect(inputPath, resource.openInputStream(), Math.toIntExact(resource.size()));
 					}

--- a/maven-plugins/transformer-maven-plugin/src/main/java/org/eclipse/transformer/maven/action/TransformerJarAction.java
+++ b/maven-plugins/transformer-maven-plugin/src/main/java/org/eclipse/transformer/maven/action/TransformerJarAction.java
@@ -20,6 +20,7 @@ import java.util.jar.Manifest;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionSelector;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
@@ -35,8 +36,8 @@ import aQute.bnd.osgi.Resource;
 
 public class TransformerJarAction extends ContainerActionImpl {
 
-	public TransformerJarAction(ActionInitData initData, ActionSelector selector, boolean overwrite) {
-		super(initData, selector);
+	public TransformerJarAction(ActionContext context, ActionSelector selector, boolean overwrite) {
+		super(context, selector);
 		this.overwrite = overwrite;
 	}
 

--- a/org.eclipse.transformer.jakarta/src/main/java/org/eclipse/transformer/jakarta/JakartaTransform.java
+++ b/org.eclipse.transformer.jakarta/src/main/java/org/eclipse/transformer/jakarta/JakartaTransform.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 
 public class JakartaTransform {
 
+	public static final String	DEFAULT_SELECTION_REFERENCE		= "jakarta-selection.properties";
 	public static final String	DEFAULT_RENAMES_REFERENCE		= "jakarta-renames.properties";
 	public static final String	DEFAULT_VERSIONS_REFERENCE		= "jakarta-versions.properties";
 	public static final String	DEFAULT_BUNDLES_REFERENCE		= "jakarta-bundles.properties";
@@ -31,6 +32,7 @@ public class JakartaTransform {
 	public static Map<String, String> getOptionDefaults() {
 		Map<String, String> optionDefaults = new HashMap<>();
 
+		optionDefaults.put("selection", DEFAULT_SELECTION_REFERENCE);
 		optionDefaults.put("renames", DEFAULT_RENAMES_REFERENCE);
 		optionDefaults.put("versions", DEFAULT_VERSIONS_REFERENCE);
 		optionDefaults.put("bundles", DEFAULT_BUNDLES_REFERENCE);

--- a/org.eclipse.transformer.jakarta/src/main/resources/org/eclipse/transformer/jakarta/jakarta-selection.properties
+++ b/org.eclipse.transformer.jakarta/src/main/resources/org/eclipse/transformer/jakarta/jakarta-selection.properties
@@ -1,0 +1,40 @@
+# Default jakarta resource selections.
+#
+# The selection rules are used to select which encountered
+# resource names are to be transformed and also what charset
+# to use for text-based resources.
+#
+# Format:
+# resource-selector=charset-name
+#
+# The resource-selector is either:
+# - an exact resource name,
+# - a '*' prefixed resource name that is matched with "endsWith",
+# - a '*' suffixed resource name that is matched with "startsWith",
+# - a '*' prefixed and '*' suffixed resource name that is matched with "contains", or
+# - '*' which is the catch-all.
+# The charset-name must be a valid Charset name understood by the JVM using
+# Charset.forName. A charset-name value of the empty string means the
+# default charset of UTF-8.
+# If the charset-name value is prefixed with '!', then it is an exclusion rule.
+# Otherwise, it is an inclusion rule. To be transformed, a resource name
+# must match an inclusion rule and not match an exclusion rule.
+#
+# Examples:
+#
+# The following includes all resource names and uses ISO-8859-1 as the charset
+# for all text-based resources.
+# *=ISO-8859-1
+#
+# The following includes all resource names except for names starting with "foo/"
+# and uses IOS-88590-1 as the charset for properties resources and UTF-8 for all
+# other text-based resources.
+# *=UTF-8
+# *.properties=ISO-8859-1
+# foo/*=!
+
+# Default when no selection rules are specified. All resources are processed
+# and the UTF-8 charset is used for all text-based resources.
+# *=UTF-8
+
+*=UTF-8

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionSelector;
 import org.eclipse.transformer.action.BundleData;
 import org.eclipse.transformer.action.Changes;
@@ -41,7 +42,7 @@ import org.eclipse.transformer.action.ContainerChanges;
 import org.eclipse.transformer.action.InputBuffer;
 import org.eclipse.transformer.action.SelectionRule;
 import org.eclipse.transformer.action.SignatureRule;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.ActionSelectorImpl;
 import org.eclipse.transformer.action.impl.BundleDataImpl;
 import org.eclipse.transformer.action.impl.ClassActionImpl;
@@ -1113,27 +1114,27 @@ public class Transformer {
 
 	// As a separate method to allow re-use.
 
-	public Action.ActionInitData getActionInitData() {
-		return new ActionImpl.ActionInitDataImpl(getLogger(), getBuffer(), getSelectionRule(), getSignatureRule());
+	public ActionContext getActionContext() {
+		return new ActionContextImpl(getLogger(), getBuffer(), getSelectionRule(), getSignatureRule());
 	}
 
 	public ActionSelector getActionSelector() {
 		if (actionSelector == null) {
 			ActionSelector useSelector = new ActionSelectorImpl();
-			Action.ActionInitData initData = getActionInitData();
+			ActionContext context = getActionContext();
 
-			ContainerAction directoryAction = useSelector.addUsing(DirectoryActionImpl::new, initData);
+			ContainerAction directoryAction = useSelector.addUsing(DirectoryActionImpl::new, context);
 
-			Action classAction = useSelector.addUsing(ClassActionImpl::new, initData);
+			Action classAction = useSelector.addUsing(ClassActionImpl::new, context);
 			// The java and JSP actions must be before the text action.
-			Action javaAction = useSelector.addUsing(JavaActionImpl::new, initData);
-			Action jspAction = useSelector.addUsing(JSPActionImpl::new, initData);
-			Action serviceConfigAction = useSelector.addUsing(ServiceLoaderConfigActionImpl::new, initData);
-			Action manifestAction = useSelector.addUsing(ManifestActionImpl::newManifestAction, initData);
-			Action featureAction = useSelector.addUsing(ManifestActionImpl::newFeatureAction, initData);
-			Action textAction = useSelector.addUsing(TextActionImpl::new, initData);
-			// Action xmlAction = useRootAction.addUsing( XmlActionImpl::new, initData );
-			Action propertiesAction = useSelector.addUsing(PropertiesActionImpl::new, initData);
+			Action javaAction = useSelector.addUsing(JavaActionImpl::new, context);
+			Action jspAction = useSelector.addUsing(JSPActionImpl::new, context);
+			Action serviceConfigAction = useSelector.addUsing(ServiceLoaderConfigActionImpl::new, context);
+			Action manifestAction = useSelector.addUsing(ManifestActionImpl::newManifestAction, context);
+			Action featureAction = useSelector.addUsing(ManifestActionImpl::newFeatureAction, context);
+			Action textAction = useSelector.addUsing(TextActionImpl::new, context);
+			// Action xmlAction = useRootAction.addUsing( XmlActionImpl::new, context );
+			Action propertiesAction = useSelector.addUsing(PropertiesActionImpl::new, context);
 
 			List<Action> standardActions = new ArrayList<>();
 			standardActions.add(classAction);
@@ -1144,13 +1145,13 @@ public class Transformer {
 			standardActions.add(featureAction);
 			standardActions.add(textAction);
 
-			ContainerAction jarAction = useSelector.addUsing(ZipActionImpl::newJarAction, initData);
-			ContainerAction warAction = useSelector.addUsing(ZipActionImpl::newWarAction, initData);
-			ContainerAction rarAction = useSelector.addUsing(ZipActionImpl::newRarAction, initData);
-			ContainerAction earAction = useSelector.addUsing(ZipActionImpl::newEarAction, initData);
-			ContainerAction zipAction = useSelector.addUsing(ZipActionImpl::newZipAction, initData);
+			ContainerAction jarAction = useSelector.addUsing(ZipActionImpl::newJarAction, context);
+			ContainerAction warAction = useSelector.addUsing(ZipActionImpl::newWarAction, context);
+			ContainerAction rarAction = useSelector.addUsing(ZipActionImpl::newRarAction, context);
+			ContainerAction earAction = useSelector.addUsing(ZipActionImpl::newEarAction, context);
+			ContainerAction zipAction = useSelector.addUsing(ZipActionImpl::newZipAction, context);
 
-			Action renameAction = useSelector.addUsing(RenameActionImpl::new, initData);
+			Action renameAction = useSelector.addUsing(RenameActionImpl::new, context);
 
 			// Directory actions know about all actions except for directory
 			// actions, and except for the properties action.

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -109,8 +109,8 @@ public class Transformer {
 	 */
 	private URI								base	= IO.work.toURI();
 
-	public Set<String>						includes;
-	public Set<String>						excludes;
+	public Map<String, String>				includes;
+	public Map<String, String>				excludes;
 
 	public boolean							invert;
 	public Map<String, String>				packageRenames;
@@ -334,8 +334,8 @@ public class Transformer {
 		invert = options.hasOption(AppOption.INVERT);
 
 		if ( !selectionProperties.isEmpty() ) {
-			includes = new HashSet<>();
-			excludes = new HashSet<>();
+			includes = new HashMap<>();
+			excludes = new HashMap<>();
 			TransformProperties.addSelections(includes, excludes, selectionProperties);
 			getLogger().info(consoleMarker, "Selection rules are in use");
 		} else {
@@ -494,14 +494,14 @@ public class Transformer {
 		}
 	}
 
-	private void addImmediateSelection(String selection, @SuppressWarnings("unused") String ignored) {
+	private void addImmediateSelection(String selection, String charset) {
 		if ( includes == null ) {
-			includes = new HashSet<>();
-			excludes = new HashSet<>();
+			includes = new HashMap<>();
+			excludes = new HashMap<>();
 			getLogger().info(consoleMarker, "Selection rules use forced by immediate data");
 		}
 
-		TransformProperties.addSelection(includes, excludes, selection);
+		TransformProperties.addSelection(includes, excludes, selection, charset);
 	}
 
 	private void addImmediateRename(
@@ -870,16 +870,14 @@ public class Transformer {
 		if ((includes == null) || includes.isEmpty()) {
 			getLogger().debug("  [ ** NONE ** ]");
 		} else {
-			for (String include : includes) {
-				getLogger().debug("  [ {} ]", include);
-			}
+			includes.forEach((include, charset) -> getLogger().debug("  [ {} ] [ {} ]", include, charset));
 		}
 
 		getLogger().debug("Excludes:");
 		if ((excludes == null) || excludes.isEmpty()) {
 			getLogger().debug("  [ ** NONE ** ]");
 		} else {
-			for (String exclude : excludes) {
+			for (String exclude : excludes.keySet()) {
 				getLogger().debug("  [ {} ]", exclude);
 			}
 		}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
@@ -113,7 +113,9 @@ public interface Action {
 	 * @param resourceName The name of the resource.
 	 * @return True or false telling if the resource is to be transformed.
 	 */
-	boolean selectResource(String resourceName);
+	default boolean selectResource(String resourceName) {
+		return getResourceSelectionRule().select(resourceName);
+	}
 
 	//
 
@@ -164,7 +166,9 @@ public interface Action {
 	 * @param inputPath The initial path to the resource.
 	 * @return An output path for the resource.
 	 */
-	String relocateResource(String inputPath);
+	default String relocateResource(String inputPath) {
+		return getSignatureRule().relocateResource(inputPath);
+	}
 
 	/**
 	 * Stop recording transformation of a resource.
@@ -193,7 +197,10 @@ public interface Action {
 	 * @param inputResourceName The input resource name.
 	 * @param outputResourceName The output resource name.
 	 */
-	void setResourceNames(String inputResourceName, String outputResourceName);
+	default void setResourceNames(String inputResourceName, String outputResourceName) {
+		getActiveChanges().setInputResourceName(inputResourceName)
+			.setOutputResourceName(outputResourceName);
+	}
 
 	//
 
@@ -203,7 +210,9 @@ public interface Action {
 	 * @return True or false telling if the current application of this action
 	 *         had changes.
 	 */
-	boolean isChanged();
+	default boolean isChanged() {
+		return getActiveChanges().isChanged();
+	}
 
 	/**
 	 * Tell if the current application of this action had changes other than a
@@ -212,7 +221,9 @@ public interface Action {
 	 * @return True or false telling if the current application of this action
 	 *         had changes other than resource name changes.
 	 */
-	boolean isContentChanged();
+	default boolean isContentChanged() {
+		return getActiveChanges().isContentChanged();
+	}
 
 	/**
 	 * Tell if the current application of this action changed the name of the
@@ -221,7 +232,9 @@ public interface Action {
 	 * @return True or false telling if the current application of this action
 	 *         changed the name of the resource.
 	 */
-	boolean isRenamed();
+	default boolean isRenamed() {
+		return getActiveChanges().isRenamed();
+	}
 
 	//
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
@@ -225,13 +225,4 @@ public interface Action {
 
 	//
 
-	public interface ActionInitData {
-		Logger getLogger();
-
-		InputBuffer getBuffer();
-
-		SelectionRule getSelectionRule();
-
-		SignatureRule getSignatureRule();
-	}
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/Action.java
@@ -12,6 +12,7 @@
 package org.eclipse.transformer.action;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 import org.eclipse.transformer.TransformException;
 import org.slf4j.Logger;
@@ -115,6 +116,16 @@ public interface Action {
 	 */
 	default boolean selectResource(String resourceName) {
 		return getResourceSelectionRule().select(resourceName);
+	}
+
+	/**
+	 * Return the charset for the specified resource name.
+	 *
+	 * @param resourceName The name of the resource.
+	 * @return The charset to use when reading or writing.
+	 */
+	default Charset resourceCharset(String resourceName) {
+		return getResourceSelectionRule().charset(resourceName);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ActionContext.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ActionContext.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.eclipse.transformer.action;
+
+import org.slf4j.Logger;
+
+public interface ActionContext {
+	Logger getLogger();
+
+	InputBuffer getBuffer();
+
+	SelectionRule getSelectionRule();
+
+	SignatureRule getSignatureRule();
+}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ActionSelector.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ActionSelector.java
@@ -32,8 +32,8 @@ public interface ActionSelector {
 		getActions().addAll(actions);
 	}
 
-	default <ACTION extends Action> ACTION addUsing(Function<? super Action.ActionInitData, ACTION> init, Action.ActionInitData initData){
-		ACTION action = init.apply(initData);
+	default <ACTION extends Action> ACTION addUsing(Function<? super ActionContext, ACTION> init, ActionContext context){
+		ACTION action = init.apply(context);
 		addAction(action);
 		return action;
 	}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ByteData.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ByteData.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 /**
  * A byte data buffer.
@@ -77,6 +78,13 @@ public interface ByteData {
 	 * @return A reader on this buffer.
 	 */
 	BufferedReader reader();
+
+	/**
+	 * The charset to use for this ByteData.
+	 *
+	 * @return The charset to use for this ByteData.
+	 */
+	Charset charset();
 
 	/**
 	 * Copy this byte data to an output stream.

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ByteData.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/ByteData.java
@@ -13,6 +13,7 @@ package org.eclipse.transformer.action;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
@@ -64,8 +65,15 @@ public interface ByteData {
 	//
 
 	/**
-	 * Answer a reader over this buffer.
+	 * Return an input stream over this buffer.
 	 *
+	 * @return An input stream over this buffer.
+	 */
+	InputStream stream();
+
+	/**
+	 * Answer a reader over this buffer.
+	 * The reader uses the charset returned by {@link #charset()}.
 	 * @return A reader on this buffer.
 	 */
 	BufferedReader reader();

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/InputBuffer.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/InputBuffer.java
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
  * and write operations occurring synchronously in a single thread.
  * <p>
  * This type is part of the action API: The type is expected by
- * {@link Action.ActionInitData}.
+ * {@link ActionContext}.
  */
 public interface InputBuffer {
 	/**

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/SelectionRule.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/SelectionRule.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.transformer.action;
 
+import java.nio.charset.Charset;
+
 public interface SelectionRule {
 	boolean select(String resourceName);
 
@@ -18,4 +20,5 @@ public interface SelectionRule {
 
 	boolean rejectExcluded(String resourceName);
 
+	Charset charset(String resourceName);
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionContextImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionContextImpl.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.eclipse.transformer.action.impl;
+
+import static java.util.Objects.requireNonNull;
+
+import org.eclipse.transformer.action.ActionContext;
+import org.eclipse.transformer.action.InputBuffer;
+import org.eclipse.transformer.action.SelectionRule;
+import org.eclipse.transformer.action.SignatureRule;
+import org.slf4j.Logger;
+
+public class ActionContextImpl implements ActionContext {
+	public ActionContextImpl(Logger logger, InputBuffer inputBuffer, SelectionRule selectionRule, SignatureRule signatureRule) {
+		this.logger = requireNonNull(logger);
+		this.inputBuffer = requireNonNull(inputBuffer);
+		this.selectionRule = requireNonNull(selectionRule);
+		this.signatureRule = requireNonNull(signatureRule);
+	}
+
+	private final Logger logger;
+	private final InputBuffer inputBuffer;
+	private final SelectionRule selectionRule;
+	private final SignatureRule signatureRule;
+
+	@Override
+	public Logger getLogger() {
+		return logger;
+	}
+
+	@Override
+	public InputBuffer getBuffer() {
+		return inputBuffer;
+	}
+
+	@Override
+	public SelectionRule getSelectionRule() {
+		return selectionRule;
+	}
+
+	@Override
+	public SignatureRule getSignatureRule() {
+		return signatureRule;
+	}
+}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.transformer.action.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +26,7 @@ import java.util.Map;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.BundleData;
 import org.eclipse.transformer.action.ByteData;
@@ -80,68 +83,26 @@ import aQute.lib.io.IO;
  * unnecessary reallocations of the buffer while transforming many resources.
  */
 public abstract class ActionImpl implements Action {
-	public ActionImpl(ActionInitData initData) {
-		this.logger = initData.getLogger();
-
-		// Transformation rules data ...
-
-		this.resourceSelectionRule = initData.getSelectionRule();
-		this.signatureRule = initData.getSignatureRule();
+	public ActionImpl(ActionContext context) {
+		this.context = requireNonNull(context);
 
 		// Change tracking ...
 
 		this.changes = new ArrayDeque<>();
 		this.activeChanges = null;
 		this.lastActiveChanges = null;
-
-		// Buffer for the resource which is being transformed.
-
-		this.buffer = initData.getBuffer();
 	}
 
 	//
 
-	public static class ActionInitDataImpl implements ActionInitData {
-		public ActionInitDataImpl(Logger logger, InputBuffer inputBuffer, SelectionRule selectionRule,
-			SignatureRule signatureRule) {
-			this.logger = logger;
-			this.inputBuffer = inputBuffer;
-			this.selectionRule = selectionRule;
-			this.signatureRule = signatureRule;
-		}
+	private final ActionContext context;
 
-		private final Logger		logger;
-		private final InputBuffer	inputBuffer;
-		private final SelectionRule	selectionRule;
-		private final SignatureRule	signatureRule;
-
-		@Override
-		public Logger getLogger() {
-			return logger;
-		}
-
-		@Override
-		public InputBuffer getBuffer() {
-			return inputBuffer;
-		}
-
-		@Override
-		public SelectionRule getSelectionRule() {
-			return selectionRule;
-		}
-
-		@Override
-		public SignatureRule getSignatureRule() {
-			return signatureRule;
-		}
+	protected ActionContext getContext() {
+		return context;
 	}
-
-	//
-
-	private final Logger logger;
 
 	protected Logger getLogger() {
-		return logger;
+		return getContext().getLogger();
 	}
 
 	//
@@ -154,11 +115,9 @@ public abstract class ActionImpl implements Action {
 
 	//
 
-	private final SelectionRule resourceSelectionRule;
-
 	@Override
 	public SelectionRule getResourceSelectionRule() {
-		return resourceSelectionRule;
+		return getContext().getSelectionRule();
 	}
 
 	@Override
@@ -168,11 +127,9 @@ public abstract class ActionImpl implements Action {
 
 	//
 
-	private final SignatureRule signatureRule;
-
 	@Override
 	public SignatureRule getSignatureRule() {
-		return signatureRule;
+		return getContext().getSignatureRule();
 	}
 
 	public Map<String, String> getPackageRenames() {
@@ -339,10 +296,8 @@ public abstract class ActionImpl implements Action {
 
 	//
 
-	private final InputBuffer buffer;
-
 	protected InputBuffer getBuffer() {
-		return buffer;
+		return getContext().getBuffer();
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
@@ -120,11 +120,6 @@ public abstract class ActionImpl implements Action {
 		return getContext().getSelectionRule();
 	}
 
-	@Override
-	public boolean selectResource(String resourceName) {
-		return getResourceSelectionRule().select(resourceName);
-	}
-
 	//
 
 	@Override
@@ -192,11 +187,6 @@ public abstract class ActionImpl implements Action {
 		return getSignatureRule().transformSignature(initialSignature, signatureType);
 	}
 
-	@Override
-	public String relocateResource(String inputPath) {
-		return getSignatureRule().relocateResource(inputPath);
-	}
-
 	//
 
 	@Override
@@ -262,29 +252,6 @@ public abstract class ActionImpl implements Action {
 	@Override
 	public Changes getActiveChanges() {
 		return activeChanges;
-	}
-
-	@Override
-	public void setResourceNames(String inputResourceName, String outputResourceName) {
-		getActiveChanges().setInputResourceName(inputResourceName)
-			.setOutputResourceName(outputResourceName);
-	}
-
-	//
-
-	@Override
-	public boolean isChanged() {
-		return getActiveChanges().isChanged();
-	}
-
-	@Override
-	public boolean isRenamed() {
-		return getActiveChanges().isRenamed();
-	}
-
-	@Override
-	public boolean isContentChanged() {
-		return getActiveChanges().isContentChanged();
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ActionImpl.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 
+import aQute.lib.io.IO;
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.Action;
 import org.eclipse.transformer.action.ActionContext;
@@ -37,8 +39,6 @@ import org.eclipse.transformer.action.SignatureRule;
 import org.eclipse.transformer.action.SignatureRule.SignatureType;
 import org.eclipse.transformer.util.FileUtils;
 import org.slf4j.Logger;
-
-import aQute.lib.io.IO;
 
 /**
  * <em>Root action implementation.</em>
@@ -294,8 +294,9 @@ public abstract class ActionImpl implements Action {
 		// This is a good case for a category of files and entries which should
 		// be omitted.
 
+		Charset charset = resourceCharset(inputName);
 		try {
-			return FileUtils.read(getLogger(), inputName, inputStream, inputCount, getBuffer());
+			return FileUtils.read(getLogger(), inputName, charset, inputStream, inputCount, getBuffer());
 		} catch (IOException e) {
 			throw new TransformException("Failed to read [ " + inputName + " ] count [ " + inputCount + " ]", e);
 		}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ByteDataImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ByteDataImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.transformer.action.impl;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
@@ -67,6 +68,11 @@ public class ByteDataImpl implements ByteData {
 	}
 
 	//
+
+	@Override
+	public InputStream stream() {
+		return FileUtils.stream(buffer());
+	}
 
 	@Override
 	public BufferedReader reader() {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ByteDataImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ByteDataImpl.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.util.FileUtils;
@@ -38,19 +39,22 @@ public class ByteDataImpl implements ByteData {
 	 *
 	 * @param name A name associated with the data.
 	 * @param buffer Byte data associated with the name.
+	 * @param charset The charset for the byte data.
 	 */
-	public ByteDataImpl(String name, ByteBuffer buffer) {
+	public ByteDataImpl(String name, ByteBuffer buffer, Charset charset) {
 		this.name = name;
 		this.buffer = buffer;
+		this.charset = charset;
 	}
 
 	@Override
 	public String toString() {
-		return super.toString() + "(name=\"" + name + "\", buffer=" + buffer + ")";
+		return super.toString() + "(name=\"" + name + "\", buffer=" + buffer + ", charset=" + charset + ")";
 	}
 
 	private final String		name;
 	private final ByteBuffer	buffer;
+	private final Charset		charset;
 
 	@Override
 	public String name() {
@@ -76,7 +80,12 @@ public class ByteDataImpl implements ByteData {
 
 	@Override
 	public BufferedReader reader() {
-		return FileUtils.reader(buffer());
+		return FileUtils.reader(buffer(), charset());
+	}
+
+	@Override
+	public Charset charset() {
+		return charset;
 	}
 
 	@Override
@@ -93,6 +102,6 @@ public class ByteDataImpl implements ByteData {
 
 	@Override
 	public ByteDataImpl copy(String name) {
-		return new ByteDataImpl(name, buffer());
+		return new ByteDataImpl(name, buffer(), charset());
 	}
 }

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
@@ -16,6 +16,7 @@ import static org.eclipse.transformer.util.SignatureUtils.classNameToResourceNam
 import java.io.DataInput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -494,6 +495,7 @@ public class ClassActionImpl extends ElementActionImpl {
 
 			ClassFile outputClass = classBuilder.build();
 
+			Charset charset = inputData.charset();
 			ByteBufferDataOutput outputClassData = new ByteBufferDataOutput(inputData.length() + FileUtils.PAGE_SIZE);
 			try {
 				outputClass.write(outputClassData);
@@ -501,7 +503,7 @@ public class ClassActionImpl extends ElementActionImpl {
 				throw new TransformException("Failed to write transformed class bytes", e);
 			}
 
-			ByteData outputData = new ByteDataImpl(outputName, outputClassData.toByteBuffer());
+			ByteData outputData = new ByteDataImpl(outputName, outputClassData.toByteBuffer(), charset);
 			useLogger.debug("  Class output: [ {} ]", outputData);
 			return outputData;
 		} finally {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ClassActionImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.ListIterator;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.action.SignatureRule;
@@ -236,10 +237,10 @@ public class ClassActionImpl extends ElementActionImpl {
 		return line;
 	}
 
-	public ClassActionImpl(ActionInitData initData) {
-		super(initData);
+	public ClassActionImpl(ActionContext context) {
+		super(context);
 
-		List<StringReplacement> useReplacements = createActiveReplacements(initData.getSignatureRule());
+		List<StringReplacement> useReplacements = createActiveReplacements(context.getSignatureRule());
 
 		this.activeReplacements = useReplacements.isEmpty() ? NO_ACTIVE_REPLACEMENTS : useReplacements;
 	}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ContainerActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ContainerActionImpl.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.util.function.Function;
 
 import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionSelector;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ContainerAction;
@@ -40,13 +41,13 @@ import org.eclipse.transformer.action.ContainerAction;
  */
 public abstract class ContainerActionImpl extends ActionImpl implements ContainerAction {
 
-	public ContainerActionImpl(ActionInitData initData, ActionSelector actionSelector) {
-		super(initData);
+	public ContainerActionImpl(ActionContext context, ActionSelector actionSelector) {
+		super(context);
 		this.actionSelector = actionSelector;
 	}
 
-	public ContainerActionImpl(ActionInitData initData) {
-		this(initData, new ActionSelectorImpl());
+	public ContainerActionImpl(ActionContext context) {
+		this(context, new ActionSelectorImpl());
 	}
 
 	@Override
@@ -55,15 +56,8 @@ public abstract class ContainerActionImpl extends ActionImpl implements Containe
 	@Override
 	public abstract ActionType getActionType();
 
-	// Used only for testing.
-
-	private Action.ActionInitData getInitData() {
-		return new ActionImpl.ActionInitDataImpl(getLogger(), getBuffer(), getResourceSelectionRule(),
-			getSignatureRule());
-	}
-
-	public <ACTION extends Action> ACTION addUsing(Function<? super Action.ActionInitData, ACTION> init) {
-		return getActionSelector().addUsing(init, getInitData());
+	public <ACTION extends Action> ACTION addUsing(Function<? super ActionContext, ACTION> init) {
+		return getActionSelector().addUsing(init, getContext());
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/DirectoryActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/DirectoryActionImpl.java
@@ -15,6 +15,7 @@ import java.io.File;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.action.ElementAction;
@@ -31,8 +32,8 @@ import org.eclipse.transformer.util.FileUtils;
  */
 public class DirectoryActionImpl extends ContainerActionImpl {
 
-	public DirectoryActionImpl(ActionInitData initData) {
-		super(initData);
+	public DirectoryActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ElementActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ElementActionImpl.java
@@ -14,14 +14,15 @@ package org.eclipse.transformer.action.impl;
 import java.io.File;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.action.ElementAction;
 
 public abstract class ElementActionImpl extends ActionImpl implements ElementAction {
 
-	public ElementActionImpl(ActionInitData initData) {
-		super(initData);
+	public ElementActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	@Override

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JSPActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JSPActionImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.transformer.action.impl;
 import java.io.File;
 import java.util.List;
 
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.SignatureRule;
 
@@ -27,8 +28,8 @@ import org.eclipse.transformer.action.SignatureRule;
  */
 public class JSPActionImpl extends TextActionImpl {
 
-	public JSPActionImpl(ActionInitData initData) {
-		super(initData);
+	public JSPActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	// Not exactly the same as 'JavaActionImpl.createActiveReplacements'.

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JavaActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/JavaActionImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.transformer.action.impl;
 import java.io.File;
 import java.util.List;
 
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.SignatureRule;
 
@@ -27,8 +28,8 @@ import org.eclipse.transformer.action.SignatureRule;
  */
 public class JavaActionImpl extends TextActionImpl {
 
-	public JavaActionImpl(ActionInitData initData) {
-		super(initData);
+	public JavaActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	// Not exactly the same as 'JSPActionImpl.createActiveReplacements'.

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ManifestActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ManifestActionImpl.java
@@ -115,7 +115,7 @@ public class ManifestActionImpl extends ElementActionImpl {
 
 			Manifest initialManifest;
 			try {
-				initialManifest = new Manifest(FileUtils.stream(inputData));
+				initialManifest = new Manifest(inputData.stream());
 			} catch (IOException e) {
 				throw new TransformException("Failed to parse manifest [ " + inputData.name() + " ]", e);
 			}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ManifestActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ManifestActionImpl.java
@@ -24,6 +24,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.BundleData;
 import org.eclipse.transformer.action.ByteData;
@@ -57,16 +58,16 @@ public class ManifestActionImpl extends ElementActionImpl {
 	private static final boolean	IS_MANIFEST				= true;
 	private static final boolean	IS_FEATURE				= !IS_MANIFEST;
 
-	public static ManifestActionImpl newManifestAction(ActionInitData initData) {
-		return new ManifestActionImpl(initData, IS_MANIFEST);
+	public static ManifestActionImpl newManifestAction(ActionContext context) {
+		return new ManifestActionImpl(context, IS_MANIFEST);
 	}
 
-	public static ManifestActionImpl newFeatureAction(ActionInitData initData) {
-		return new ManifestActionImpl(initData, IS_FEATURE);
+	public static ManifestActionImpl newFeatureAction(ActionContext context) {
+		return new ManifestActionImpl(context, IS_FEATURE);
 	}
 
-	public ManifestActionImpl(ActionInitData initData, boolean isManifest) {
-		super(initData);
+	public ManifestActionImpl(ActionContext context, boolean isManifest) {
+		super(context);
 		this.isManifest = isManifest;
 	}
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ManifestActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ManifestActionImpl.java
@@ -18,6 +18,7 @@ import static org.eclipse.transformer.util.SignatureUtils.stripWildcard;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -129,6 +130,7 @@ public class ManifestActionImpl extends ElementActionImpl {
 				return inputData;
 			}
 
+			Charset charset = inputData.charset();
 			ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 			try {
 				write(finalManifest, outputStream);
@@ -136,7 +138,7 @@ public class ManifestActionImpl extends ElementActionImpl {
 				throw new TransformException("Failed to write manifest [ " + inputData.name() + " ]", e);
 			}
 
-			ByteData outputData = new ByteDataImpl(inputData.name(), outputStream.toByteBuffer());
+			ByteData outputData = new ByteDataImpl(inputData.name(), outputStream.toByteBuffer(), charset);
 			getLogger().debug("[ {}.{} ]: Final [ {} ]", className, methodName, outputData);
 			return outputData;
 		} finally {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/PropertiesActionImpl.java
@@ -12,6 +12,7 @@
 package org.eclipse.transformer.action.impl;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 
@@ -31,8 +32,8 @@ import org.eclipse.transformer.action.ByteData;
  */
 public class PropertiesActionImpl extends ElementActionImpl {
 
-	public PropertiesActionImpl(ActionInitData initData) {
-		super(initData);
+	public PropertiesActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	@Override

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/RenameActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/RenameActionImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.transformer.action.impl;
 import java.io.File;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.action.RenameAction;
@@ -25,8 +26,8 @@ import org.eclipse.transformer.action.RenameAction;
  */
 public class RenameActionImpl extends ElementActionImpl implements RenameAction {
 
-	public RenameActionImpl(ActionInitData initData) {
-		super(initData);
+	public RenameActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.ActionContext;
@@ -112,7 +113,8 @@ public class ServiceLoaderConfigActionImpl extends ElementActionImpl {
 
 			ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 
-			try (BufferedReader reader = inputData.reader(); BufferedWriter writer = FileUtils.writer(outputStream)) {
+			Charset charset = inputData.charset();
+			try (BufferedReader reader = inputData.reader(); BufferedWriter writer = FileUtils.writer(outputStream, charset)) {
 				transform(reader, writer);
 			} catch (IOException e) {
 				throw new TransformException("Failed to transform [ " + inputName + " ]", e);
@@ -123,7 +125,7 @@ public class ServiceLoaderConfigActionImpl extends ElementActionImpl {
 			} else if (!isContentChanged()) {
 				return inputData.copy(outputName);
 			} else {
-				return new ByteDataImpl(outputName, outputStream.toByteBuffer());
+				return new ByteDataImpl(outputName, outputStream.toByteBuffer(), charset);
 			}
 
 		} finally {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ServiceLoaderConfigActionImpl.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.util.FileUtils;
@@ -41,8 +42,8 @@ public class ServiceLoaderConfigActionImpl extends ElementActionImpl {
 
 	//
 
-	public ServiceLoaderConfigActionImpl(ActionInitData initData) {
-		super(initData);
+	public ServiceLoaderConfigActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.action.SignatureRule;
@@ -39,10 +40,10 @@ import aQute.lib.io.ByteBufferOutputStream;
  */
 public class TextActionImpl extends ElementActionImpl {
 
-	public TextActionImpl(ActionInitData initData) {
-		super(initData);
+	public TextActionImpl(ActionContext context) {
+		super(context);
 
-		List<StringReplacement> replacements = createActiveReplacements(initData.getSignatureRule());
+		List<StringReplacement> replacements = createActiveReplacements(context.getSignatureRule());
 		this.activeReplacements = replacements.isEmpty() ? NO_ACTIVE_REPLACEMENTS : replacements;
 	}
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/TextActionImpl.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,7 +95,8 @@ public class TextActionImpl extends ElementActionImpl {
 
 			ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 
-			try (BufferedReader reader = inputData.reader(); BufferedWriter writer = FileUtils.writer(outputStream)) {
+			Charset charset = inputData.charset();
+			try (BufferedReader reader = inputData.reader(); BufferedWriter writer = FileUtils.writer(outputStream, charset)) {
 				transform(inputName, reader, writer);
 			} catch (IOException e) {
 				throw new TransformException("Failed to transform [ " + inputName + " ]", e);
@@ -105,7 +107,7 @@ public class TextActionImpl extends ElementActionImpl {
 			} else if (!isContentChanged()) {
 				return inputData.copy(outputName);
 			} else {
-				return new ByteDataImpl(outputName, outputStream.toByteBuffer());
+				return new ByteDataImpl(outputName, outputStream.toByteBuffer(), charset);
 			}
 
 		} finally {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
@@ -99,7 +99,7 @@ public class XmlActionImpl extends ElementActionImpl {
 	static final boolean XML_AS_PLAIN_TEXT;
 	static {
 		String value = System.getProperty("XML_AS_PLAIN_TEXT", "true");
-		XML_AS_PLAIN_TEXT = Boolean.valueOf(value);
+		XML_AS_PLAIN_TEXT = Boolean.parseBoolean(value);
 	}
 
 	@Override
@@ -117,7 +117,7 @@ public class XmlActionImpl extends ElementActionImpl {
 
 			ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 
-			transformUsingSaxParser(inputName, FileUtils.stream(inputData), outputStream);
+			transformUsingSaxParser(inputName, inputData.stream(), outputStream);
 
 			if (!isChanged()) {
 				return inputData;

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/XmlActionImpl.java
@@ -26,6 +26,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.eclipse.transformer.TransformException;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.util.FileUtils;
@@ -55,8 +56,8 @@ import aQute.lib.io.ByteBufferOutputStream;
  */
 public class XmlActionImpl extends ElementActionImpl {
 
-	public XmlActionImpl(ActionInitData initData) {
-		super(initData);
+	public XmlActionImpl(ActionContext context) {
+		super(context);
 	}
 
 	//

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
@@ -146,7 +146,7 @@ public class ZipActionImpl extends ContainerActionImpl implements ElementAction 
 			ByteBuffer outputBuffer = isContentChanged()
 				? outputStream.toByteBuffer()
 				: inputData.buffer();
-			ByteData outputData = new ByteDataImpl(outputPath, outputBuffer);
+			ByteData outputData = new ByteDataImpl(outputPath, outputBuffer, inputData.charset());
 			return outputData;
 		} finally {
 			stopRecording(inputPath);

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
@@ -26,6 +26,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ActionType;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.action.ElementAction;
@@ -51,29 +52,29 @@ import aQute.lib.io.IO;
  */
 public class ZipActionImpl extends ContainerActionImpl implements ElementAction {
 
-	public static ZipActionImpl newZipAction(ActionInitData initData) {
-		return new ZipActionImpl(initData, "Zip Action", ActionType.ZIP, ".zip");
+	public static ZipActionImpl newZipAction(ActionContext context) {
+		return new ZipActionImpl(context, "Zip Action", ActionType.ZIP, ".zip");
 	}
 
-	public static ZipActionImpl newJarAction(ActionInitData initData) {
-		return new ZipActionImpl(initData, "Jar Action", ActionType.JAR, ".jar");
+	public static ZipActionImpl newJarAction(ActionContext context) {
+		return new ZipActionImpl(context, "Jar Action", ActionType.JAR, ".jar");
 	}
 
-	public static ZipActionImpl newWarAction(ActionInitData initData) {
-		return new ZipActionImpl(initData, "WAR Action", ActionType.WAR, ".war");
+	public static ZipActionImpl newWarAction(ActionContext context) {
+		return new ZipActionImpl(context, "WAR Action", ActionType.WAR, ".war");
 	}
 
-	public static ZipActionImpl newRarAction(ActionInitData initData) {
-		return new ZipActionImpl(initData, "RAR Action", ActionType.RAR, ".rar");
+	public static ZipActionImpl newRarAction(ActionContext context) {
+		return new ZipActionImpl(context, "RAR Action", ActionType.RAR, ".rar");
 	}
 
-	public static ZipActionImpl newEarAction(ActionInitData initData) {
-		return new ZipActionImpl(initData, "EAR Action", ActionType.EAR, ".ear");
+	public static ZipActionImpl newEarAction(ActionContext context) {
+		return new ZipActionImpl(context, "EAR Action", ActionType.EAR, ".ear");
 	}
 
-	public ZipActionImpl(ActionInitData initData, String name, ActionType actionType,
-		String extension) {
-		super(initData);
+	public ZipActionImpl(ActionContext context, String name, ActionType actionType,
+						 String extension) {
+		super(context);
 
 		this.name = name;
 		this.actionType = actionType;

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
@@ -137,7 +137,7 @@ public class ZipActionImpl extends ContainerActionImpl implements ElementAction 
 		try {
 			String outputPath = relocateResource(inputPath);
 			setResourceNames(inputPath, outputPath);
-			InputStream inputStream = FileUtils.stream(inputData);
+			InputStream inputStream = inputData.stream();
 			ByteBufferOutputStream outputStream = new ByteBufferOutputStream(inputData.length());
 			applyStream(inputPath, inputStream, outputPath, outputStream);
 			if (!isChanged()) {

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/util/FileUtils.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/util/FileUtils.java
@@ -11,8 +11,6 @@
 
 package org.eclipse.transformer.util;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -20,18 +18,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
+import aQute.lib.io.IO;
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.ByteData;
 import org.eclipse.transformer.action.InputBuffer;
 import org.eclipse.transformer.action.impl.ByteDataImpl;
 import org.slf4j.Logger;
-
-import aQute.lib.io.ByteBufferInputStream;
-import aQute.lib.io.IO;
 
 public class FileUtils {
 	private FileUtils() {}
@@ -44,6 +42,12 @@ public class FileUtils {
 
 	/** Maximum array size. Adjusted per ByteArrayInputStream comments. */
 	public static final int	MAX_ARRAY_LENGTH	= Integer.MAX_VALUE - 8;
+
+	/**
+	 * Default Charset to use when the selection rules do not specify a
+	 * charset for a resource.
+	 */
+	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
 	/**
 	 * Verify that an integer value is usable as an array size.
@@ -110,7 +114,7 @@ public class FileUtils {
 	 * @throws IOException Thrown if a read fails, or if overflow or underflow
 	 *             occurs.
 	 */
-	public static ByteData read(Logger logger, String inputName, InputStream inputStream, int requested, InputBuffer inputBuffer)
+	public static ByteData read(Logger logger, String inputName, Charset charset, InputStream inputStream, int requested, InputBuffer inputBuffer)
 		throws IOException {
 
 		logger.debug("Reading [ {} ] bytes [ {} ]", inputName, requested);
@@ -127,12 +131,7 @@ public class FileUtils {
 			logger.debug("Read [ {} ] bytes [ {} ]", inputName, finalBuffer.limit());
 		}
 
-		return new ByteDataImpl(inputName, finalBuffer);
-	}
-
-	public static ByteData read(Logger logger, String inputName, InputStream inputStream, InputBuffer inputBuffer)
-		throws IOException {
-		return read(logger, inputName, inputStream, -1, inputBuffer);
+		return new ByteDataImpl(inputName, finalBuffer, charset);
 	}
 
 	/**
@@ -313,8 +312,8 @@ public class FileUtils {
 		return reader;
 	}
 
-	public static BufferedWriter writer(OutputStream outputStream) {
-		OutputStreamWriter outputWriter = new OutputStreamWriter(outputStream, UTF_8);
+	public static BufferedWriter writer(OutputStream outputStream, Charset charset) {
+		OutputStreamWriter outputWriter = new OutputStreamWriter(outputStream, charset);
 		BufferedWriter writer = new BufferedWriter(outputWriter);
 		return writer;
 	}

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/util/FileUtils.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/util/FileUtils.java
@@ -303,12 +303,13 @@ public class FileUtils {
 
 	//
 
-	public static InputStream stream(ByteData byteData) {
-		return new ByteBufferInputStream(byteData.buffer());
+	public static InputStream stream(ByteBuffer buffer) {
+		InputStream stream = IO.stream(buffer);
+		return stream;
 	}
 
-	public static BufferedReader reader(ByteBuffer buffer) {
-		BufferedReader reader = IO.reader(buffer, UTF_8);
+	public static BufferedReader reader(ByteBuffer buffer, Charset charset) {
+		BufferedReader reader = IO.reader(buffer, charset);
 		return reader;
 	}
 

--- a/org.eclipse.transformer/src/test/java/transformer/test/CaptureTest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/CaptureTest.java
@@ -14,14 +14,12 @@ package transformer.test;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.transformer.action.BundleData;
 import org.eclipse.transformer.action.impl.InputBufferImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
 import org.eclipse.transformer.action.impl.SignatureRuleImpl;
 import org.slf4j.Logger;
-
 import transformer.test.util.CaptureLoggerImpl;
 
 public class CaptureTest {
@@ -64,7 +62,7 @@ public class CaptureTest {
 
 	//
 
-	public SelectionRuleImpl createSelectionRule(Logger useLogger, Set<String> useIncludes, Set<String> useExcludes) {
+	public SelectionRuleImpl createSelectionRule(Logger useLogger, Map<String, String> useIncludes, Map<String, String> useExcludes) {
 		return new SelectionRuleImpl(useLogger, useIncludes, useExcludes);
 	}
 

--- a/org.eclipse.transformer/src/test/java/transformer/test/ClassActionTest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/ClassActionTest.java
@@ -25,9 +25,9 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
-import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ByteData;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.ByteDataImpl;
 import org.eclipse.transformer.action.impl.ClassActionImpl;
 import org.eclipse.transformer.action.impl.InputBufferImpl;
@@ -121,10 +121,10 @@ public class ClassActionTest {
 		renames.put("original.provides.impl", "transformed.provides.impl");
 		renames.put("original.main", "transformed.main");
 
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(logger, new InputBufferImpl(),
+		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
-		ClassActionImpl classAction = new ClassActionImpl(initData);
+		ClassActionImpl classAction = new ClassActionImpl(context);
 
 		ByteData outputData = classAction.apply(inputData);
 
@@ -217,11 +217,11 @@ public class ClassActionTest {
 		Map<String, String> renames = new HashMap<>();
 		renames.put("original.host", "transformed.host");
 		renames.put("original.member", "transformed.member");
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(logger, new InputBufferImpl(),
+		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
 
-		ClassActionImpl classAction = new ClassActionImpl(initData);
+		ClassActionImpl classAction = new ClassActionImpl(context);
 		ByteData outputData = classAction.apply(inputData);
 
 		ClassFile transformed = ClassFile.parseClassFile(ByteBufferDataInput.wrap(outputData.buffer()));
@@ -261,10 +261,10 @@ public class ClassActionTest {
 		renames.put("original.enclosing", "transformed.enclosing");
 		renames.put("original.param", "transformed.param");
 		renames.put("original.result", "transformed.result");
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(logger, new InputBufferImpl(),
+		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
-		ClassActionImpl classAction = new ClassActionImpl(initData);
+		ClassActionImpl classAction = new ClassActionImpl(context);
 		ByteData outputData = classAction.apply(inputData);
 
 		ClassFile transformed = ClassFile.parseClassFile(ByteBufferDataInput.wrap(outputData.buffer()));

--- a/org.eclipse.transformer/src/test/java/transformer/test/ClassActionTest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/ClassActionTest.java
@@ -23,22 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
-import org.eclipse.transformer.action.ActionContext;
-import org.eclipse.transformer.action.ByteData;
-import org.eclipse.transformer.action.impl.ActionContextImpl;
-import org.eclipse.transformer.action.impl.ByteDataImpl;
-import org.eclipse.transformer.action.impl.ClassActionImpl;
-import org.eclipse.transformer.action.impl.InputBufferImpl;
-import org.eclipse.transformer.action.impl.SelectionRuleImpl;
-import org.eclipse.transformer.action.impl.SignatureRuleImpl;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import aQute.bnd.classfile.Attribute;
 import aQute.bnd.classfile.ClassFile;
 import aQute.bnd.classfile.ElementInfo;
@@ -52,6 +36,22 @@ import aQute.bnd.classfile.builder.ClassFileBuilder;
 import aQute.bnd.classfile.builder.ModuleInfoBuilder;
 import aQute.lib.io.ByteBufferDataInput;
 import aQute.lib.io.ByteBufferDataOutput;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import org.eclipse.transformer.action.ActionContext;
+import org.eclipse.transformer.action.ByteData;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
+import org.eclipse.transformer.action.impl.ByteDataImpl;
+import org.eclipse.transformer.action.impl.ClassActionImpl;
+import org.eclipse.transformer.action.impl.InputBufferImpl;
+import org.eclipse.transformer.action.impl.SelectionRuleImpl;
+import org.eclipse.transformer.action.impl.SignatureRuleImpl;
+import org.eclipse.transformer.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ClassActionTest {
 	Logger	logger;
@@ -111,7 +111,7 @@ public class ClassActionTest {
 
 		ByteBufferDataOutput dataOutput = new ByteBufferDataOutput();
 		original.write(dataOutput);
-		ByteData inputData = new ByteDataImpl(testName, dataOutput.toByteBuffer());
+		ByteData inputData = new ByteDataImpl(testName, dataOutput.toByteBuffer(), FileUtils.DEFAULT_CHARSET);
 
 		Map<String, String> renames = new HashMap<>();
 		renames.put("original.exports", "transformed.exports");
@@ -122,7 +122,7 @@ public class ClassActionTest {
 		renames.put("original.main", "transformed.main");
 
 		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
-			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
+			new SelectionRuleImpl(logger, Collections.emptyMap(), Collections.emptyMap()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
 		ClassActionImpl classAction = new ClassActionImpl(context);
 
@@ -212,13 +212,13 @@ public class ClassActionTest {
 
 		ByteBufferDataOutput dataOutput = new ByteBufferDataOutput();
 		original.write(dataOutput);
-		ByteData inputData = new ByteDataImpl(testName, dataOutput.toByteBuffer());
+		ByteData inputData = new ByteDataImpl(testName, dataOutput.toByteBuffer(), FileUtils.DEFAULT_CHARSET);
 
 		Map<String, String> renames = new HashMap<>();
 		renames.put("original.host", "transformed.host");
 		renames.put("original.member", "transformed.member");
 		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
-			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
+			new SelectionRuleImpl(logger, Collections.emptyMap(), Collections.emptyMap()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
 
 		ClassActionImpl classAction = new ClassActionImpl(context);
@@ -255,14 +255,14 @@ public class ClassActionTest {
 
 		ByteBufferDataOutput dataOutput = new ByteBufferDataOutput();
 		original.write(dataOutput);
-		ByteData inputData = new ByteDataImpl(testName, dataOutput.toByteBuffer());
+		ByteData inputData = new ByteDataImpl(testName, dataOutput.toByteBuffer(), FileUtils.DEFAULT_CHARSET);
 
 		Map<String, String> renames = new HashMap<>();
 		renames.put("original.enclosing", "transformed.enclosing");
 		renames.put("original.param", "transformed.param");
 		renames.put("original.result", "transformed.result");
 		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
-			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()),
+			new SelectionRuleImpl(logger, Collections.emptyMap(), Collections.emptyMap()),
 			new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
 		ClassActionImpl classAction = new ClassActionImpl(context);
 		ByteData outputData = classAction.apply(inputData);

--- a/org.eclipse.transformer/src/test/java/transformer/test/RenameActionTest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/RenameActionTest.java
@@ -16,8 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.reflect.Method;
 import java.util.Collections;
 
-import org.eclipse.transformer.action.Action;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.ActionContext;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.InputBufferImpl;
 import org.eclipse.transformer.action.impl.RenameActionImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
@@ -50,10 +50,10 @@ class RenameActionTest {
 
 	@Test
 	void relocate_resource() {
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(logger, new InputBufferImpl(),
+		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
 			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()), new SignatureRuleImpl(logger,
 				Maps.of("com.a.b.*", "com.shaded.a.b"), null, null, null, null, null, Collections.emptyMap()));
-		RenameActionImpl action = new RenameActionImpl(initData);
+		RenameActionImpl action = new RenameActionImpl(context);
 
 		assertThat(action.relocateResource("a/b/c/packageinfo")).isEqualTo("a/b/c/packageinfo");
 		assertThat(action.relocateResource("com/a/b/c/packageinfo")).isEqualTo("com/shaded/a/b/c/packageinfo");

--- a/org.eclipse.transformer/src/test/java/transformer/test/RenameActionTest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/RenameActionTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.reflect.Method;
 import java.util.Collections;
 
+import aQute.bnd.unmodifiable.Maps;
 import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.InputBufferImpl;
@@ -27,8 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import aQute.bnd.unmodifiable.Maps;
 
 /**
  *
@@ -51,7 +50,7 @@ class RenameActionTest {
 	@Test
 	void relocate_resource() {
 		ActionContext context = new ActionContextImpl(logger, new InputBufferImpl(),
-			new SelectionRuleImpl(logger, Collections.emptySet(), Collections.emptySet()), new SignatureRuleImpl(logger,
+			new SelectionRuleImpl(logger, Collections.emptyMap(), Collections.emptyMap()), new SignatureRuleImpl(logger,
 				Maps.of("com.a.b.*", "com.shaded.a.b"), null, null, null, null, null, Collections.emptyMap()));
 		RenameActionImpl action = new RenameActionImpl(context);
 

--- a/org.eclipse.transformer/src/test/java/transformer/test/SelectionTests.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/SelectionTests.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package transformer.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import aQute.lib.utf8properties.UTF8Properties;
+import org.eclipse.transformer.TransformProperties;
+import org.eclipse.transformer.action.impl.SelectionRuleImpl;
+import org.junit.jupiter.api.Test;
+import transformer.test.util.CaptureLoggerImpl;
+
+class SelectionTests {
+	CaptureLoggerImpl useLogger = new CaptureLoggerImpl("Test", !CaptureLoggerImpl.CAPTURE_INACTIVE);
+
+	@Test
+	void selections() throws Exception {
+		UTF8Properties properties = new UTF8Properties();
+		properties.load("# comment\n*=UTF-8\n*.properties=ISO-8859-1\n*Abstract*=US-ASCII\nwide/*=UTF-16\n! comment\n*.proto=!", null, null);
+		Map<String, String> selectionProperties = new HashMap<>();
+		properties.forEach((k,v) -> {
+			selectionProperties.put(k.toString(), v.toString());
+		});
+		Map<String, String> includes = new HashMap<>();
+		Map<String, String> excludes = new HashMap<>();
+		TransformProperties.addSelections(includes, excludes, selectionProperties);
+		SelectionRuleImpl selectionRule = new SelectionRuleImpl(useLogger, includes, excludes);
+		assertThat(selectionRule.select("foo.txt")).isTrue();
+		assertThat(selectionRule.charset("foo.txt")).isEqualTo(StandardCharsets.UTF_8);
+		assertThat(selectionRule.select("foo.properties")).isTrue();
+		assertThat(selectionRule.charset("foo.properties")).isEqualTo(StandardCharsets.ISO_8859_1);
+		assertThat(selectionRule.select("bar/AbstractThing.class")).isTrue();
+		assertThat(selectionRule.charset("bar/AbstractThing.class")).isEqualTo(StandardCharsets.US_ASCII);
+		assertThat(selectionRule.select("wide/file.txt")).isTrue();
+		assertThat(selectionRule.charset("wide/file.txt")).isEqualTo(StandardCharsets.UTF_16);
+		assertThat(selectionRule.select("foo.proto")).isFalse();
+	}
+}

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
@@ -566,7 +566,7 @@ public class TestTransformClass extends CaptureTest {
 		display(classAction.getLastActiveChanges());
 
 		ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
-		FileUtils.transfer(FileUtils.stream(outputStreamData), capturedOutput);
+		FileUtils.transfer(outputStreamData.stream(), capturedOutput);
 		byte[] outputBytes = capturedOutput.toByteArray();
 		display("Output class size [ %s ]", outputBytes.length);
 		ClassFile outputClass = parse(outputBytes);

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
@@ -35,9 +35,9 @@ import java.util.Set;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.TransformProperties;
-import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ByteData;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.ClassActionImpl;
 import org.eclipse.transformer.action.impl.ClassChangesImpl;
 import org.eclipse.transformer.action.impl.ServiceLoaderConfigActionImpl;
@@ -349,11 +349,11 @@ public class TestTransformClass extends CaptureTest {
 		if (toJakartaJarAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getToJakartaRenames(), null, null, null, Collections.emptyMap()));
 
-			toJakartaJarAction = ZipActionImpl.newJarAction(initData);
+			toJakartaJarAction = ZipActionImpl.newJarAction(context);
 		}
 
 		return toJakartaJarAction;
@@ -367,11 +367,11 @@ public class TestTransformClass extends CaptureTest {
 
 			Map<String, String> toJavaxRenames = TransformProperties.invert(getToJakartaRenames());
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, toJavaxRenames, null, null, null, Collections.emptyMap()));
 
-			toJavaxJarAction = ZipActionImpl.newJarAction(initData);
+			toJavaxJarAction = ZipActionImpl.newJarAction(context);
 		}
 
 		return toJavaxJarAction;
@@ -383,11 +383,11 @@ public class TestTransformClass extends CaptureTest {
 		if (toJakartaJarAction_DirectOverride == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getOverrideIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getToJakartaRenames(), null, null, toJakartaDirectStrings(), null));
 
-			toJakartaJarAction_DirectOverride = ZipActionImpl.newJarAction(initData);
+			toJakartaJarAction_DirectOverride = ZipActionImpl.newJarAction(context);
 		}
 
 		return toJakartaJarAction_DirectOverride;
@@ -399,12 +399,12 @@ public class TestTransformClass extends CaptureTest {
 		if (toJakartaJarAction_PerClassDirectOverride == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getOverrideIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getToJakartaRenames(), null, null, toJakartaDirectStrings(),
 					toJakartaPerClassDirectStrings()));
 
-			toJakartaJarAction_PerClassDirectOverride = ZipActionImpl.newJarAction(initData);
+			toJakartaJarAction_PerClassDirectOverride = ZipActionImpl.newJarAction(context);
 		}
 
 		return toJakartaJarAction_PerClassDirectOverride;
@@ -416,11 +416,11 @@ public class TestTransformClass extends CaptureTest {
 		if (toJakartaJarAction_PackageRenamesOnly == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getOverrideIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getToJakartaRenames(), null, null, null, null));
 
-			toJakartaJarAction_PackageRenamesOnly = ZipActionImpl.newJarAction(initData);
+			toJakartaJarAction_PackageRenamesOnly = ZipActionImpl.newJarAction(context);
 		}
 
 		return toJakartaJarAction_PackageRenamesOnly;
@@ -529,11 +529,11 @@ public class TestTransformClass extends CaptureTest {
 	public ClassActionImpl createToJakartaClassAction() {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
 			createSignatureRule(useLogger, getToJakartaRenames(), null, null, null, Collections.emptyMap()));
 
-		return new ClassActionImpl(initData);
+		return new ClassActionImpl(context);
 	}
 
 	protected void toJakartaRewrite(String simpleClassName) throws TransformException, IOException {
@@ -830,21 +830,21 @@ public class TestTransformClass extends CaptureTest {
 	public ClassActionImpl createDirectClassAction() {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()), createSignatureRule(
 				useLogger, Collections.emptyMap(), null, null, getDirectStrings(), Collections.emptyMap()));
 
-		return new ClassActionImpl(initData);
+		return new ClassActionImpl(context);
 	}
 
 	public ClassActionImpl createPerClassConstantClassAction() {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
 			createSignatureRule(useLogger, Collections.emptyMap(), null, null, null, PER_CLASS_CONSTANT_MASTER));
 
-		return new ClassActionImpl(initData);
+		return new ClassActionImpl(context);
 	}
 
 	public static final String DIRECT_STRINGS_RESOURCE_NAME = "Sample_DirectStrings.class";
@@ -1205,10 +1205,10 @@ public class TestTransformClass extends CaptureTest {
 	public ClassActionImpl createStandardClassAction() throws IOException {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
-		Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
 			createSignatureRule(useLogger, getStandardRenames(), null, null, null, Collections.emptyMap()));
 
-		return new ClassActionImpl(initData);
+		return new ClassActionImpl(context);
 	}
 }

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformClass.java
@@ -25,14 +25,21 @@ import java.io.Reader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
+import aQute.bnd.classfile.AnnotationInfo;
+import aQute.bnd.classfile.AnnotationsAttribute;
+import aQute.bnd.classfile.Attribute;
+import aQute.bnd.classfile.ClassFile;
+import aQute.bnd.classfile.ElementValueInfo;
+import aQute.bnd.classfile.FieldInfo;
+import aQute.bnd.classfile.MethodInfo;
+import aQute.lib.io.ByteBufferDataInput;
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.TransformProperties;
 import org.eclipse.transformer.action.ActionContext;
@@ -49,15 +56,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import aQute.bnd.classfile.AnnotationInfo;
-import aQute.bnd.classfile.AnnotationsAttribute;
-import aQute.bnd.classfile.Attribute;
-import aQute.bnd.classfile.ClassFile;
-import aQute.bnd.classfile.ElementValueInfo;
-import aQute.bnd.classfile.FieldInfo;
-import aQute.bnd.classfile.MethodInfo;
-import aQute.lib.io.ByteBufferDataInput;
 import transformer.test.data.Sample_InjectAPI_Jakarta;
 import transformer.test.data.Sample_InjectAPI_Javax;
 import transformer.test.data.Sample_Repeat_Target;
@@ -213,27 +211,21 @@ public class TestTransformClass extends CaptureTest {
 
 	//
 
-	protected Set<String> includes;
+	protected Map<String, String> includes;
 
-	public Set<String> getIncludes() {
+	public Map<String, String> getIncludes() {
 		if (includes == null) {
-			includes = new HashSet<>();
-			includes.add(SignatureUtils.classNameToResourceName(INJECT_JAVAX_CLASS_NAME));
-			includes.add(SignatureUtils.classNameToResourceName(INJECT_JAKARTA_CLASS_NAME));
-
-			includes.add(SignatureUtils.classNameToResourceName(REPEAT_TARGET_CLASS_NAME));
-
-			// includes.add( TEST_DATA_RESOURCE_NAME + '/' +
-			// ANNOTATED_SERVLET_SIMPLE_CLASS_NAME);
-			// includes.add( TEST_DATA_RESOURCE_NAME + '/' +
-			// MIXED_SERVLET_SIMPLE_CLASS_NAME);
+			includes = new HashMap<>();
+			includes.put(SignatureUtils.classNameToResourceName(INJECT_JAVAX_CLASS_NAME), "");
+			includes.put(SignatureUtils.classNameToResourceName(INJECT_JAKARTA_CLASS_NAME), "");
+			includes.put(SignatureUtils.classNameToResourceName(REPEAT_TARGET_CLASS_NAME), "");
 		}
 
 		return includes;
 	}
 
-	public Set<String> getExcludes() {
-		return Collections.emptySet();
+	public Map<String, String> getExcludes() {
+		return Collections.emptyMap();
 	}
 
 	protected Map<String, String> toJakartaRenames;
@@ -266,9 +258,9 @@ public class TestTransformClass extends CaptureTest {
 	public static final String	OVERRIDE_TARGET_RESOURCE_NAME	= SignatureUtils
 		.classNameToResourceName(OVERRIDE_TARGET_CLASS_NAME);
 
-	public Set<String> getOverrideIncludes() {
-		Set<String> overrideIncludes = new HashSet<>();
-		overrideIncludes.add(OVERRIDE_TARGET_RESOURCE_NAME);
+	public Map<String, String> getOverrideIncludes() {
+		Map<String, String> overrideIncludes = new HashMap<>();
+		overrideIncludes.put(OVERRIDE_TARGET_RESOURCE_NAME, FileUtils.DEFAULT_CHARSET.name());
 		return overrideIncludes;
 	}
 
@@ -530,7 +522,7 @@ public class TestTransformClass extends CaptureTest {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
 		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
-			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
+			createSelectionRule(useLogger, Collections.emptyMap(), Collections.emptyMap()),
 			createSignatureRule(useLogger, getToJakartaRenames(), null, null, null, Collections.emptyMap()));
 
 		return new ClassActionImpl(context);
@@ -831,7 +823,7 @@ public class TestTransformClass extends CaptureTest {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
 		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
-			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()), createSignatureRule(
+			createSelectionRule(useLogger, Collections.emptyMap(), Collections.emptyMap()), createSignatureRule(
 				useLogger, Collections.emptyMap(), null, null, getDirectStrings(), Collections.emptyMap()));
 
 		return new ClassActionImpl(context);
@@ -841,7 +833,7 @@ public class TestTransformClass extends CaptureTest {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
 		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
-			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
+			createSelectionRule(useLogger, Collections.emptyMap(), Collections.emptyMap()),
 			createSignatureRule(useLogger, Collections.emptyMap(), null, null, null, PER_CLASS_CONSTANT_MASTER));
 
 		return new ClassActionImpl(context);
@@ -1206,7 +1198,7 @@ public class TestTransformClass extends CaptureTest {
 		CaptureLoggerImpl useLogger = getCaptureLogger();
 
 		ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
-			createSelectionRule(useLogger, Collections.emptySet(), Collections.emptySet()),
+			createSelectionRule(useLogger, Collections.emptyMap(), Collections.emptyMap()),
 			createSignatureRule(useLogger, getStandardRenames(), null, null, null, Collections.emptyMap()));
 
 		return new ClassActionImpl(context);

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.TransformProperties;
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import transformer.test.util.CaptureLoggerImpl;
 
 public class TestTransformManifest extends CaptureTest {
@@ -105,12 +103,12 @@ public class TestTransformManifest extends CaptureTest {
 	public static final String	JAKARTA_TRANSACTION_TSR				= "jakarta.transaction.TransactionSynchronizationRegistry";
 	public static final String	JAKARTA_TRANSACTION_UT				= "jakarta.transaction.UserTransaction";
 
-	public Set<String> getIncludes() {
-		return Collections.emptySet();
+	public Map<String, String> getIncludes() {
+		return Collections.emptyMap();
 	}
 
-	public Set<String> getExcludes() {
-		return Collections.emptySet();
+	public Map<String, String> getExcludes() {
+		return Collections.emptyMap();
 	}
 
 	public Map<String, String> getPackageRenames() {

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
@@ -27,10 +27,10 @@ import java.util.Set;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.TransformProperties;
-import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.BundleData;
 import org.eclipse.transformer.action.ByteData;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.BundleDataImpl;
 import org.eclipse.transformer.action.impl.InputBufferImpl;
 import org.eclipse.transformer.action.impl.ManifestActionImpl;
@@ -200,12 +200,12 @@ public class TestTransformManifest extends CaptureTest {
 		if (jakartaManifestAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, getBundleUpdates(),
 					null, getDirectStrings(), Collections.emptyMap()));
 
-			jakartaManifestAction = ManifestActionImpl.newManifestAction(initData);
+			jakartaManifestAction = ManifestActionImpl.newManifestAction(context);
 		}
 		return jakartaManifestAction;
 	}
@@ -216,12 +216,12 @@ public class TestTransformManifest extends CaptureTest {
 		if (jakartaFeatureAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger, getPackageRenames(), getPackageVersions(), null, null, null, null,
 					Collections.emptyMap()));
 
-			jakartaFeatureAction = ManifestActionImpl.newFeatureAction(initData);
+			jakartaFeatureAction = ManifestActionImpl.newFeatureAction(context);
 		}
 
 		return jakartaFeatureAction;
@@ -235,12 +235,12 @@ public class TestTransformManifest extends CaptureTest {
 		if (jakartaManifestActionTx == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), null, getBundleUpdatesTx(), null, getDirectStrings(),
 					Collections.emptyMap()));
 
-			jakartaManifestActionTx = ManifestActionImpl.newManifestAction(initData);
+			jakartaManifestActionTx = ManifestActionImpl.newManifestAction(context);
 
 		}
 		return jakartaManifestActionTx;
@@ -252,12 +252,12 @@ public class TestTransformManifest extends CaptureTest {
 		if (specificJakartaManifestAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), getSpecificPackageVersions(), getBundleUpdatesTx(),
 					null, getDirectStrings(), Collections.emptyMap()));
 
-			specificJakartaManifestAction = ManifestActionImpl.newManifestAction(initData);
+			specificJakartaManifestAction = ManifestActionImpl.newManifestAction(context);
 		}
 
 		return specificJakartaManifestAction;
@@ -618,8 +618,8 @@ public class TestTransformManifest extends CaptureTest {
 	 * Subclass which allows us to call protected methods of ManifestActionImpl
 	 */
 	class ManifestActionImpl_Test extends ManifestActionImpl {
-		public ManifestActionImpl_Test(ActionInitData initData) {
-			super(initData, true);
+		public ManifestActionImpl_Test(ActionContext context) {
+			super(context, true);
 		}
 
 		public boolean callIsTrueMatch(String text, int matchStart, int keyLen) {
@@ -645,10 +645,10 @@ public class TestTransformManifest extends CaptureTest {
 		if (manifestAction_test == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()), new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), null, null, null, null, Collections.emptyMap()));
-			manifestAction_test = new ManifestActionImpl_Test(initData);
+			manifestAction_test = new ManifestActionImpl_Test(context);
 		}
 
 		return manifestAction_test;
@@ -660,13 +660,13 @@ public class TestTransformManifest extends CaptureTest {
 		if (specificManifestAction_test == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger,
 					getPackageRenames(), getPackageVersions(), getSpecificPackageVersions(),
 					null, null, null, Collections.emptyMap()));
 
-			specificManifestAction_test = new ManifestActionImpl_Test(initData);
+			specificManifestAction_test = new ManifestActionImpl_Test(context);
 		}
 
 		return specificManifestAction_test;

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformManifest.java
@@ -361,7 +361,7 @@ public class TestTransformManifest extends CaptureTest {
 			manifestOutput = manifestAction.apply(manifestAction.collect(inputPath, input));
 		}
 
-		List<String> outputLines = displayManifest(inputPath + " transformed", FileUtils.stream(manifestOutput));
+		List<String> outputLines = displayManifest(inputPath + " transformed", manifestOutput.stream());
 
 		System.out.println("Verify output [ " + inputPath + " ]");
 

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
@@ -19,8 +19,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.eclipse.transformer.TransformException;
-import org.eclipse.transformer.action.Action;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.ActionContext;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.InputBufferImpl;
 import org.eclipse.transformer.action.impl.PropertiesActionImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
@@ -96,11 +96,11 @@ public class TestTransformPropertiesFile extends CaptureTest {
 		if (jakartaPropertiesAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getPackageRenames()));
 
-			jakartaPropertiesAction = new PropertiesActionImpl(initData);
+			jakartaPropertiesAction = new PropertiesActionImpl(context);
 
 		}
 		return jakartaPropertiesAction;

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformPropertiesFile.java
@@ -11,12 +11,11 @@
 package transformer.test;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.ActionContext;
@@ -25,11 +24,11 @@ import org.eclipse.transformer.action.impl.InputBufferImpl;
 import org.eclipse.transformer.action.impl.PropertiesActionImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
 import org.eclipse.transformer.action.impl.SignatureRuleImpl;
+import org.eclipse.transformer.util.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import transformer.test.util.CaptureLoggerImpl;
 
 public class TestTransformPropertiesFile extends CaptureTest {
@@ -46,8 +45,8 @@ public class TestTransformPropertiesFile extends CaptureTest {
 		System.setProperties(prior);
 	}
 
-	public SelectionRuleImpl createSelectionRule(CaptureLoggerImpl useLogger, Set<String> useIncludes,
-		Set<String> useExcludes) {
+	public SelectionRuleImpl createSelectionRule(CaptureLoggerImpl useLogger, Map<String, String> useIncludes,
+												 Map<String, String> useExcludes) {
 
 		return new SelectionRuleImpl(useLogger, useIncludes, useExcludes);
 	}
@@ -65,19 +64,19 @@ public class TestTransformPropertiesFile extends CaptureTest {
 
 	public static final String	JAKARTA_PATH	= "jakarta/servlet/Bundle.properties";
 
-	protected Set<String>		includes;
+	protected Map<String, String>		includes;
 
-	public Set<String> getIncludes() {
+	public Map<String, String> getIncludes() {
 		if (includes == null) {
-			includes = new HashSet<>();
-			includes.add(JAVAX_PATH);
+			includes = new HashMap<>();
+			includes.put(JAVAX_PATH, FileUtils.DEFAULT_CHARSET.name());
 		}
 
 		return includes;
 	}
 
-	public Set<String> getExcludes() {
-		return Collections.emptySet();
+	public Map<String, String> getExcludes() {
+		return Collections.emptyMap();
 	}
 
 	protected Map<String, String> packageRenames;

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
@@ -15,13 +15,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -46,7 +45,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import transformer.test.util.CaptureLoggerImpl;
 
 public class TestTransformServiceConfig extends CaptureTest {
@@ -64,8 +62,8 @@ public class TestTransformServiceConfig extends CaptureTest {
 		System.setProperties(prior);
 	}
 
-	public SelectionRuleImpl createSelectionRule(CaptureLoggerImpl useLogger, Set<String> useIncludes,
-		Set<String> useExcludes) {
+	public SelectionRuleImpl createSelectionRule(CaptureLoggerImpl useLogger, Map<String, String> useIncludes,
+												 Map<String, String> useExcludes) {
 
 		return new SelectionRuleImpl(useLogger, useIncludes, useExcludes);
 	}
@@ -128,20 +126,20 @@ public class TestTransformServiceConfig extends CaptureTest {
 	public static final String		JAKARTA_SERVLET_HTTP_VERSION		= "[2.6, 6.0)";
 	public static final String		JAKARTA_SERVLET_RESOURCES_VERSION	= "[2.6, 6.0)";
 
-	protected Set<String>			includes;
+	protected Map<String, String>			includes;
 
-	public Set<String> getIncludes() {
+	public Map<String, String> getIncludes() {
 		if (includes == null) {
-			includes = new HashSet<>();
-			includes.add(JAVAX_SAMPLE_READER_SERVICE_PATH);
-			includes.add(JAVAX_SAMPLE_WRITER_SERVICE_PATH);
+			includes = new HashMap<>();
+			includes.put(JAVAX_SAMPLE_READER_SERVICE_PATH, FileUtils.DEFAULT_CHARSET.name());
+			includes.put(JAVAX_SAMPLE_WRITER_SERVICE_PATH, FileUtils.DEFAULT_CHARSET.name());
 		}
 
 		return includes;
 	}
 
-	public Set<String> getExcludes() {
-		return Collections.emptySet();
+	public Map<String, String> getExcludes() {
+		return Collections.emptyMap();
 	}
 
 	protected Map<String, String> packageRenames;
@@ -195,7 +193,7 @@ public class TestTransformServiceConfig extends CaptureTest {
 			ActionSelectorImpl actionSelector = new ActionSelectorImpl();
 
 			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
-				createSelectionRule(useLogger, Collections.emptySet(), getExcludes()),
+				createSelectionRule(useLogger, Collections.emptyMap(), getExcludes()),
 				createSignatureRule(useLogger, invertedRenames, null, null, null));
 
 			jarJavaxServiceAction = ZipActionImpl.newJarAction(context);

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
@@ -27,10 +27,10 @@ import java.util.zip.ZipInputStream;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.TransformProperties;
-import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.BundleData;
 import org.eclipse.transformer.action.ByteData;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.ActionSelectorImpl;
 import org.eclipse.transformer.action.impl.PropertiesActionImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
@@ -162,11 +162,11 @@ public class TestTransformServiceConfig extends CaptureTest {
 		if (jakartaServiceAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, getPackageRenames(), null, null, null));
 
-			jakartaServiceAction = new ServiceLoaderConfigActionImpl(initData);
+			jakartaServiceAction = new ServiceLoaderConfigActionImpl(context);
 		}
 		return jakartaServiceAction;
 	}
@@ -177,11 +177,11 @@ public class TestTransformServiceConfig extends CaptureTest {
 
 			Map<String, String> invertedRenames = TransformProperties.invert(getPackageRenames());
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, getIncludes(), getExcludes()),
 				createSignatureRule(useLogger, invertedRenames, null, null, null));
 
-			javaxServiceAction = new ServiceLoaderConfigActionImpl(initData);
+			javaxServiceAction = new ServiceLoaderConfigActionImpl(context);
 		}
 		return javaxServiceAction;
 	}
@@ -194,11 +194,11 @@ public class TestTransformServiceConfig extends CaptureTest {
 
 			ActionSelectorImpl actionSelector = new ActionSelectorImpl();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, createBuffer(),
+			ActionContext context = new ActionContextImpl(useLogger, createBuffer(),
 				createSelectionRule(useLogger, Collections.emptySet(), getExcludes()),
 				createSignatureRule(useLogger, invertedRenames, null, null, null));
 
-			jarJavaxServiceAction = ZipActionImpl.newJarAction(initData);
+			jarJavaxServiceAction = ZipActionImpl.newJarAction(context);
 			jarJavaxServiceAction.addUsing(PropertiesActionImpl::new);
 			jarJavaxServiceAction.addUsing(ServiceLoaderConfigActionImpl::new);
 		}

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformServiceConfig.java
@@ -284,11 +284,11 @@ public class TestTransformServiceConfig extends CaptureTest {
 			inputData = action.collect(inputName, inputStream);
 		}
 
-		List<String> inputLines = TestUtils.loadLines(FileUtils.stream(inputData));
+		List<String> inputLines = TestUtils.loadLines(inputData.stream());
 
 		ByteData transformedData = action.apply(inputData);
 
-		List<String> transformedLines = TestUtils.loadLines(FileUtils.stream(transformedData));
+		List<String> transformedLines = TestUtils.loadLines(transformedData.stream());
 		TestUtils.filter(transformedLines);
 		TestUtils.verify(inputName, expectedLines, transformedLines);
 	}

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import org.eclipse.transformer.TransformException;
 import org.eclipse.transformer.action.ActionContext;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import transformer.test.util.CaptureLoggerImpl;
 
 public class TestTransformXML extends CaptureTest {
@@ -68,12 +66,12 @@ public class TestTransformXML extends CaptureTest {
 
 	//
 
-	public Set<String> getIncludes() {
-		return Collections.emptySet();
+	public Map<String, String> getIncludes() {
+		return Collections.emptyMap();
 	}
 
-	public Set<String> getExcludes() {
-		return Collections.emptySet();
+	public Map<String, String> getExcludes() {
+		return Collections.emptyMap();
 	}
 
 	//

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
@@ -21,9 +21,9 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.eclipse.transformer.TransformException;
-import org.eclipse.transformer.action.Action;
+import org.eclipse.transformer.action.ActionContext;
 import org.eclipse.transformer.action.ByteData;
-import org.eclipse.transformer.action.impl.ActionImpl;
+import org.eclipse.transformer.action.impl.ActionContextImpl;
 import org.eclipse.transformer.action.impl.InputBufferImpl;
 import org.eclipse.transformer.action.impl.SelectionRuleImpl;
 import org.eclipse.transformer.action.impl.SignatureRuleImpl;
@@ -106,11 +106,11 @@ public class TestTransformXML extends CaptureTest {
 		if (textAction == null) {
 			CaptureLoggerImpl useLogger = getCaptureLogger();
 
-			Action.ActionInitData initData = new ActionImpl.ActionInitDataImpl(useLogger, new InputBufferImpl(),
+			ActionContext context = new ActionContextImpl(useLogger, new InputBufferImpl(),
 				new SelectionRuleImpl(useLogger, getIncludes(), getExcludes()),
 				new SignatureRuleImpl(useLogger, null, null, null, null, getMasterXmlUpdates(), null,
 					Collections.emptyMap()));
-			textAction = new TextActionImpl(initData);
+			textAction = new TextActionImpl(context);
 		}
 
 		return textAction;

--- a/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TestTransformXML.java
@@ -176,7 +176,7 @@ public class TestTransformXML extends CaptureTest {
 		List<String> finalLines;
 		try (InputStream resourceInput = TestUtils.getResourceStream(resourceRef)) {
 			ByteData xmlOutput = useTextAction.apply(useTextAction.collect(resourceRef, resourceInput));
-			finalLines = display(resourceRef, FileUtils.stream(xmlOutput));
+			finalLines = display(resourceRef, xmlOutput.stream());
 		}
 
 		verify(resourceRef, "initial lines", initialOccurrences, initialLines);

--- a/org.eclipse.transformer/src/test/java/transformer/test/TransformClassLoader.java
+++ b/org.eclipse.transformer/src/test/java/transformer/test/TransformClassLoader.java
@@ -79,7 +79,7 @@ public class TransformClassLoader extends ClassLoader {
 		ClassActionImpl classAction = getClassAction();
 		ByteData inputData = classAction.collect(resourceName, inputStream);
 		ByteData outputData = classAction.apply(inputData);
-		return FileUtils.stream(outputData);
+		return outputData.stream();
 	}
 
 	//
@@ -102,7 +102,7 @@ public class TransformClassLoader extends ClassLoader {
 		} else {
 			ByteData inputData = configAction.collect(resourceName, inputStream);
 			ByteData outputData = configAction.apply(inputData);
-			return FileUtils.stream(outputData);
+			return outputData.stream();
 		}
 	}
 


### PR DESCRIPTION
This change uses the values of selection rules to specify the charset
name for the matched resource names. Previously the selection rule
value was ignored.

In another change from before, to specify a selection exclusion, the
value (charset name) must start with '!'. This change is necessary since
the prior behavior of prefixing the selection rule key with '!' does
not work in properties files since lines starting with '!' are comments.

The default selection rule is "*=UTF-8" which selects all resource names
and uses the charset UTF-8.

Fixes https://github.com/eclipse/transformer/issues/293