### PR TITLE
Fix for the problem "Zip file conversion fails if it includes non-UTF-8 entry(such as MS932)."

### DIFF
--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
@@ -78,6 +78,8 @@ public enum AppOption {
 		Settings.NO_GROUP)),
 	OVERWRITE(new Settings("o", "overwrite", "Overwrite", !Settings.HAS_ARG, !Settings.HAS_ARGS, !Settings.IS_REQUIRED,
 		Settings.NO_GROUP)),
+	ZIP_ENTRY_ENCODE(new Settings("zipenc", "zip-entry-encode", "Entry encode in zip (default: UTF-8)", Settings.HAS_ARG,
+		!Settings.HAS_ARGS, !Settings.IS_REQUIRED, Settings.NO_GROUP)),
 
 	DRYRUN(new Settings("d", "dryrun", "Dry run", !Settings.HAS_ARG, !Settings.HAS_ARGS, !Settings.IS_REQUIRED,
 		Settings.NO_GROUP)),

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/Transformer.java
@@ -166,6 +166,16 @@ public class Transformer {
 			return ResultCode.TRANSFORM_ERROR_RC;
 		}
 
+		if (options.hasOption(AppOption.ZIP_ENTRY_ENCODE)) {
+			String zipEntryEncode = options.getOptionValue(AppOption.ZIP_ENTRY_ENCODE);
+			try {
+				ZipActionImpl.setZipEntryEncode(zipEntryEncode);
+			} catch (RuntimeException e) {
+				getLogger().error(consoleMarker, "Zip entry encode is invalid.", e);
+				return ResultCode.ARGS_ERROR_RC;
+			}
+		}
+
 		boolean loadedRules;
 		try {
 			loadedRules = setRules(getImmediateData());

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/action/impl/ZipActionImpl.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.file.attribute.FileTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -51,6 +52,11 @@ import aQute.lib.io.IO;
  * This is important for Bnd and Maven plugins.
  */
 public class ZipActionImpl extends ContainerActionImpl implements ElementAction {
+	private static Charset zipEntryEncode = Charset.forName("UTF-8");
+
+	public static void setZipEntryEncode(String zipEntryEncode) {
+		ZipActionImpl.zipEntryEncode = Charset.forName(zipEntryEncode);
+	}
 
 	public static ZipActionImpl newZipAction(ActionContext context) {
 		return new ZipActionImpl(context, "Zip Action", ActionType.ZIP, ".zip");
@@ -204,9 +210,13 @@ public class ZipActionImpl extends ContainerActionImpl implements ElementAction 
 		// base stream. We don't want that here.
 
 		try {
-			ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+			ZipInputStream zipInputStream = (actionType == ActionType.ZIP) ?
+											new ZipInputStream(inputStream, zipEntryEncode) :
+											new ZipInputStream(inputStream);
 
-			ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream);
+			ZipOutputStream zipOutputStream = (actionType == ActionType.ZIP) ?
+											new ZipOutputStream(outputStream, zipEntryEncode) :
+											new ZipOutputStream(outputStream);
 			try {
 				applyZipStream(inputPath, zipInputStream, outputPath, zipOutputStream);
 			} finally {


### PR DESCRIPTION
Fix for the problem "Zip file conversion fails if it includes non-UTF-8 entry(such as MS932)."

https://github.com/eclipse/transformer/issues/330

Signed-off-by: tsyamamoto <tsyamamoto@fujitsu.com>